### PR TITLE
Remove quotes from 'docker build' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git clone --recursive https://github.com/atlarge-research/opendc.git
 cd opendc/
 
 # Build the Docker image
-docker build -t="opendc" .
+docker build -t=opendc .
 
 # Start a container with the image
 docker run -d --name opendc -p 8081:8081 -e 'SERVER_URL=http://localhost:8081' -e 'OAUTH_CLIENT_ID=your-google-oauth-client-id' -e 'OAUTH_CLIENT_SECRET=your-google-oauth-secret' opendc


### PR DESCRIPTION
The `README.md` lists the docker command `docker build -t="opendc" .` as a build-step. The quotation-marks (`"`) are actually not necessary, since the name only consists of alphanumeric characters.