### PR TITLE
Simplify frontend build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 # JetBrains platform
 .idea/
+
+keys.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p /data/database \
 	&& cd /opendc/opendc-frontend \
 	&& rm -rf /opendc/opendc-frontend/build \
 	&& yarn \
-	&& gulp --config=../build/frontend_config.json
+	&& gulp --config=../keys.json
 
 CMD ["sh", "-c", "cd /opendc && ./build/configure.sh /data/database && /usr/bin/supervisord -c /opendc/build/supervisord.conf"]
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The simulator monitors the database for `QUEUED` experiments, and simulates them
 
 The official way to run OpenDC is using Docker. Other options include building and running locally, and building and running to deploy on a server.
 
-For all of these options, you have to create a Google API Console project and client ID, which the OpenDC frontend and web server will use to authenticate users and requests. Follow [these steps](https://developers.google.com/identity/sign-in/web/devconsole-project) to make such a project. In the 'Authorized JavaScript origins' field, be sure to add `http://localhost:8081` as origin. Download the JSON of the OAuth 2.0 client ID you created from the Credentials tab, and specifically note the `client_id` and the `client_secret`, which you'll need to build OpenDC.
+For all of these options, you have to create a Google API Console project and client ID, which the OpenDC frontend and web server will use to authenticate users and requests. Follow [these steps](https://developers.google.com/identity/sign-in/web/devconsole-project) to make such a project. In the 'Authorized JavaScript origins' field, be sure to add `http://localhost:8081` as origin. Download the JSON of the OAuth 2.0 client ID you created from the Credentials tab, and specifically note the `client_id`, which you'll need to build OpenDC.
 
 ### Installing Docker
 
@@ -46,7 +46,7 @@ Open VirtualBox, navigate to the settings of your default docker VM, and go to t
 
 ### Running OpenDC
 
-To build and run the full OpenDC stack locally on Linux or Mac, run the commands bellow. Replace `your-google-oauth-client-id` with your `client_id` from the OAuth 2.0 client ID you created, and replace `your-google-oauth-secret` with your `client_secret`.
+To build and run the full OpenDC stack locally on Linux or Mac, you first need to clone the project:
 
 ```bash
 # Clone the repo and its submodules
@@ -54,12 +54,28 @@ git clone --recursive https://github.com/atlarge-research/opendc.git
 
 # Enter the directory
 cd opendc/
+```
 
+In the directory you just entered, you need to set up a small configuration file. To do this, create a file called `keys.json` in the `opendc` folder. In this file, simply replace `your-google-oauth-client-id` with your `client_id` from the OAuth client ID you created.
+
+```json
+{
+  "OAUTH_CLIENT_ID": "your-google-oauth-client-id",
+  "SERVER_BASE_URL": "http://localhost:8081",
+  "ROOT_DIR": "/opendc",
+  "FLASK_SECRET": "This is a super duper secret flask key",
+  "DATABASE_LOCATION": "/data/database/opendc.db"
+}
+```
+
+Once this configuration file is set up, we're ready to get the install up and running:
+
+```bash
 # Build the Docker image
 docker build -t="opendc" .
 
 # Start a container with the image
-docker run -d --name opendc -p 8081:8081 -e 'SERVER_URL=http://localhost:8081' -e 'OAUTH_CLIENT_ID=your-google-oauth-client-id' -e 'OAUTH_CLIENT_SECRET=your-google-oauth-secret' opendc
+docker run -d --name opendc -p 8081:8081 opendc
 ```
 
 Wait a few seconds and open `http://localhost:8081` in your browser to use OpenDC.

--- a/README.md
+++ b/README.md
@@ -56,19 +56,19 @@ git clone --recursive https://github.com/atlarge-research/opendc.git
 cd opendc/
 ```
 
-In the directory you just entered, you need to set up a small configuration file. To do this, create a file called `keys.json` in the `opendc` folder. In this file, simply replace `your-google-oauth-client-id` with your `client_id` from the OAuth client ID you created.
+In the directory you just entered, you need to set up a small configuration file. To do this, create a file called `keys.json` in the `opendc` folder. In this file, simply replace `your-google-oauth-client-id` with your `client_id` from the OAuth client ID you created. For a standard setup, you can leave the other settings as-is.
 
 ```json
 {
-  "OAUTH_CLIENT_ID": "your-google-oauth-client-id",
-  "SERVER_BASE_URL": "http://localhost:8081",
-  "ROOT_DIR": "/opendc",
+  "DATABASE_LOCATION": "/data/database/opendc.db",
   "FLASK_SECRET": "This is a super duper secret flask key",
-  "DATABASE_LOCATION": "/data/database/opendc.db"
+  "OAUTH_CLIENT_ID": "your-google-oauth-client-id",
+  "ROOT_DIR": "/opendc",
+  "SERVER_BASE_URL": "http://localhost:8081"
 }
 ```
 
-Once this configuration file is set up, we're ready to get the install up and running:
+Now, start the server:
 
 ```bash
 # Build the Docker image

--- a/build/configure.sh
+++ b/build/configure.sh
@@ -3,32 +3,6 @@ if [ ! -f "$1/opendc.db" ]; then
 	sqlite3 "$1/opendc.db" < ./database/test.sql
 fi
 
-if [ -z "$OAUTH_CLIENT_ID" ]
-then
-	echo "OAuth client id not found. Define environment variable OAUTH_CLIENT_ID"
-	exit 1
-fi
-
-if [ -z "$OAUTH_CLIENT_SECRET" ]
-then
-	echo "OAuth client secret not found. Define environment variable OAUTH_CLIENT_SECRET"
-	exit 2
-fi
-
-if [ -z "$SERVER_URL" ]
-then
-	echo "URL of server not found. Define environment variable SERVER_URL"
-	exit 2
-fi
-
-sed -i "s/client-id/$OAUTH_CLIENT_ID/g" ./build/keys.json
-sed -i "s/client-secret/$OAUTH_CLIENT_SECRET/g" ./build/keys.json
-
 # ignore non ASCII characters
 LC_CTYPE=C
 LANG=C
-
-find ./opendc-frontend/build -type f -exec sed -i "s/the-google-oauth-client-id/$OAUTH_CLIENT_ID/g" {} \;
-find ./opendc-frontend/build -type f -exec sed -i "s,https://opendc.ewi.tudelft.nl:443,$SERVER_URL,g" {} \;
-find ./opendc-frontend/build -type f -exec sed -i "s,https://opendc.ewi.tudelft.nl,$SERVER_URL,g" {} \;
-find ./opendc-frontend/build -type f -exec sed -i 's,LOCAL_MODE = (document.location.hostname === "localhost"),LOCAL_MODE = false,g' {} \;

--- a/build/frontend_config.json
+++ b/build/frontend_config.json
@@ -1,3 +1,0 @@
-{
-    "GOOGLE_OAUTH_CLIENT_ID": "the-google-oauth-client-id"
-}

--- a/build/keys.json
+++ b/build/keys.json
@@ -1,7 +1,0 @@
-{
-    "OAUTH_CLIENT_ID": "client-id",
-    "OAUTH_CLIENT_SECRET": "client-secret",
-    "ROOT_DIR": "/opendc",
-    "FLASK_SECRET": "This is a super duper secret flask key",
-    "DATABASE_LOCATION": "/data/database/opendc.db"
-}

--- a/build/supervisord.conf
+++ b/build/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:web-server]
-command=/usr/bin/python2.7 /opendc/opendc-web-server/main.py /opendc/build/keys.json
+command=/usr/bin/python2.7 /opendc/opendc-web-server/main.py /opendc/keys.json
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
This PR refactors parts of the Docker build procedure, for a simpler and cleaner process.

Specifically, it offers the following changes:

* All configuration-specific details are moved to a JSON file. The `README` now provides a template for this `keys.json` file, which then needs to be present in the `opendc` root folder at build-time. The main difference in the Docker build process is that the `docker run` command no longer needs the OAuth client ID and server URL as inputs, since these are read from that configuration file.
* The OAuth client secret has been permanently removed from all Docker configuration steps, as it is never used by the web-server.
* The newly linked frontend-module now supports custom URL-definition. This way, the previously hard-coded server URL can be replaced with another one (such as `http://localhost:8081`), for customized setups. This base URL can be set in the `keys.json` configuration file.
* The manual Docker-string-replacements in `configure.sh` have been rendered obsolete and removed.