### PR TITLE
Fix web server crash in Docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN echo "deb http://ftp.debian.org/debian stretch main" >> /etc/apt/sources.lis
 	&& apt-get update \
 	&& apt-get install -y python python-pip yarn git sed mysql-client \
 	&& pip install oauth2client eventlet flask-socketio flask-compress mysql-connector-python-rf \
+	&& pip install --upgrade pyasn1-modules \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Copy OpenDC directory


### PR DESCRIPTION
The current web server fails on my machine when I run the Docker setup. I found out that this was a more common issue with a fix, so I've applied this fix to our setup.

This was the crash: https://github.com/etingof/pyasn1/issues/108