### PR TITLE
Use setup.py in web-server Docker install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,6 @@ MAINTAINER Sacheendra Talluri <sacheendra.t@gmail.com>
 
 # Installing python and web-server dependencies
 RUN echo "deb http://ftp.debian.org/debian stretch main" >> /etc/apt/sources.list \
-#	&& apt-get update \
-#	&& apt-get install -y apt-transport-https \
-#	&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-#	&& echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
 	&& apt-get update \
 	&& apt-get install -y python python-pip yarn git sed mysql-client \
 	&& rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,20 @@ MAINTAINER Sacheendra Talluri <sacheendra.t@gmail.com>
 
 # Installing python and web-server dependencies
 RUN echo "deb http://ftp.debian.org/debian stretch main" >> /etc/apt/sources.list \
+#	&& apt-get update \
+#	&& apt-get install -y apt-transport-https \
+#	&& curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+#	&& echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
 	&& apt-get update \
 	&& apt-get install -y python python-pip yarn git sed mysql-client \
-	&& pip install oauth2client eventlet flask-socketio flask-compress mysql-connector-python-rf \
-	&& pip install --upgrade pyasn1-modules \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Copy OpenDC directory
 COPY ./ /opendc
 
 # Setting up simulator
-RUN chmod 555 /opendc/build/configure.sh \
+RUN python /opendc/opendc-web-server/setup.py install \
+	&& chmod 555 /opendc/build/configure.sh \
 	&& cd /opendc/opendc-frontend \
 	&& rm -rf ./build \
 	&& rm -rf ./node_modules \


### PR DESCRIPTION
We already have a setup.py for the web server, so we should preferably use that for the install (instead of manual pip commands).