### PR TITLE
Configure simulator to track machine and task states

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
       - PERSISTENCE_URL=jdbc:mysql://mariadb:3306/opendc
       - PERSISTENCE_USER=opendc
       - PERSISTENCE_PASSWORD=opendcpassword
+      - COLLECT_MACHINE_STATES=ON
+      - COLLECT_TASK_STATES=ON
+      - COLLECT_STAGE_MEASUREMENTS=OFF
+      - COLLECT_TASK_METRICS=OFF
+      - COLLECT_JOB_METRICS=OFF
   mariadb:
     build:
         context: ./database


### PR DESCRIPTION
This change configures the simulator to track machine and task states
during simulation to be able to show the nice graphs in the OpenDC
frontend. During the SC18 experiments, these options were not enabled and
forgot to renable them for the website.