### PR TITLE
Added a tooltip to graphs in portfolio results

### DIFF
--- a/opendc-web/opendc-web-ui/src/components/app/results/PortfolioResultsComponent.js
+++ b/opendc-web/opendc-web-ui/src/components/app/results/PortfolioResultsComponent.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Bar, CartesianGrid, ComposedChart, ErrorBar, ResponsiveContainer, Scatter, XAxis, YAxis } from 'recharts'
+import { Bar, CartesianGrid, ComposedChart, ErrorBar, ResponsiveContainer, Scatter, Tooltip, XAxis, YAxis } from 'recharts'
 import { AVAILABLE_METRICS, METRIC_NAMES_SHORT, METRIC_UNITS } from '../../../util/available-metrics'
 import { mean, std } from 'mathjs'
 import Shapes from '../../../shapes/index'
@@ -76,6 +76,7 @@ const PortfolioResultsComponent = ({ portfolio, scenarios }) => {
                                         direction="x"
                                     />
                                 </Scatter>
+                                <Tooltip/>
                             </ComposedChart>
                         </ResponsiveContainer>
                     </div>


### PR DESCRIPTION
## Summary
A tooltip makes it easier to read exact values from the graphs.
![afbeelding](https://user-images.githubusercontent.com/32361020/138261695-41015632-c9b6-49a5-ac7b-e51ae20b4128.png)

## Implementation Notes :hammer_and_pick:

* Used the Tooltip from Recharts

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*