### PR TITLE
Activate timer even without incoming jobs

### DIFF
--- a/opendc-workflow/opendc-workflow-service/src/main/kotlin/org/opendc/workflow/service/internal/WorkflowServiceImpl.kt
+++ b/opendc-workflow/opendc-workflow-service/src/main/kotlin/org/opendc/workflow/service/internal/WorkflowServiceImpl.kt
@@ -256,7 +256,7 @@ public class WorkflowServiceImpl(
      */
     private fun requestSchedulingCycle() {
         // Bail out in case we have already requested a new cycle or the queue is empty.
-        if (timerScheduler.isTimerActive(Unit) || incomingJobs.isEmpty()) {
+        if (timerScheduler.isTimerActive(Unit)) {
             return
         }
 


### PR DESCRIPTION
This change fixes an issue where a scheduling cycle is not scheduled
when there are no incoming jobs. Still, there might be pending tasks
that can be scheduled. Therefore, we remove this conditional.