### PR TITLE
Support convergence of space shared hypervisor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifacts
         if: always()
+        continue-on-error: true # See https://github.com/actions/upload-artifact/issues/270
         uses: actions/upload-artifact@v2
         with:
           name: reports-${{ matrix.os }}-jdk${{ matrix.java }}

--- a/opendc-simulator/opendc-simulator-compute/src/main/kotlin/org/opendc/simulator/compute/kernel/SimSpaceSharedHypervisor.kt
+++ b/opendc-simulator/opendc-simulator-compute/src/main/kotlin/org/opendc/simulator/compute/kernel/SimSpaceSharedHypervisor.kt
@@ -37,7 +37,7 @@ public class SimSpaceSharedHypervisor(
     listener: FlowConvergenceListener?,
     scalingGovernor: ScalingGovernor?,
 ) : SimAbstractHypervisor(engine, listener, scalingGovernor) {
-    override val mux: FlowMultiplexer = ForwardingFlowMultiplexer(engine)
+    override val mux: FlowMultiplexer = ForwardingFlowMultiplexer(engine, this)
 
     override fun canFit(model: MachineModel): Boolean {
         return mux.outputs.size - mux.inputs.size >= model.cpus.size


### PR DESCRIPTION
## Summary

This change addresses an issue with the SimSpaceSharedHypervisor implementation where it did not emit convergence events due to missing implementation. This caused issues with users of this class trying to obtain usage data, which depended on these events being emitted.

## Implementation Notes :hammer_and_pick:

* Support `FlowConvergenceListener` in `FlowForwarder` and `ForwardingFlowMux`
* Support `FlowConvergenceListener` in `SimSpaceSharedHypervisor`.

## Breaking API Changes :warning:

* N/A