### PR TITLE
Read dependencies from .gwf trace

### DIFF
--- a/opendc-trace/opendc-trace-gwf/src/main/kotlin/org/opendc/trace/gwf/GwfTaskTableReader.kt
+++ b/opendc-trace/opendc-trace-gwf/src/main/kotlin/org/opendc/trace/gwf/GwfTaskTableReader.kt
@@ -60,7 +60,7 @@ internal class GwfTaskTableReader(private val parser: CsvParser) : TableReader {
                 "RunTime" -> runtime = Duration.ofSeconds(parser.longValue)
                 "NProcs" -> nProcs = parser.intValue
                 "ReqNProcs" -> reqNProcs = parser.intValue
-                "Dependencies" -> parseParents(parser.valueAsString)
+                "Dependencies" -> dependencies = parseParents(parser.valueAsString)
             }
         }
 
@@ -119,8 +119,8 @@ internal class GwfTaskTableReader(private val parser: CsvParser) : TableReader {
     /**
      * Parse the parents into a set of longs.
      */
-    private fun parseParents(value: String): Set<Long> {
-        val result = mutableSetOf<Long>()
+    private fun parseParents(value: String): Set<String> {
+        val result = mutableSetOf<String>()
         val deps = value.split(pattern)
 
         for (dep in deps) {
@@ -128,7 +128,7 @@ internal class GwfTaskTableReader(private val parser: CsvParser) : TableReader {
                 continue
             }
 
-            result.add(dep.toLong(10))
+            result.add(dep)
         }
 
         return result
@@ -156,7 +156,7 @@ internal class GwfTaskTableReader(private val parser: CsvParser) : TableReader {
     private var runtime: Duration? = null
     private var nProcs = -1
     private var reqNProcs = -1
-    private var dependencies = emptySet<Long>()
+    private var dependencies = emptySet<String>()
 
     /**
      * Reset the state.

--- a/opendc-trace/opendc-trace-gwf/src/test/kotlin/org/opendc/trace/gwf/GwfTraceFormatTest.kt
+++ b/opendc-trace/opendc-trace-gwf/src/test/kotlin/org/opendc/trace/gwf/GwfTraceFormatTest.kt
@@ -69,4 +69,23 @@ internal class GwfTraceFormatTest {
             { assertEquals(emptySet<String>(), reader.get(TASK_PARENTS)) },
         )
     }
+
+    @Test
+    fun testReadingRowWithDependencies() {
+        val path = Paths.get(checkNotNull(GwfTraceFormatTest::class.java.getResource("/trace.gwf")).toURI())
+        val reader = format.newReader(path, TABLE_TASKS)
+
+        // Move to row 7
+        for (x in 1..6)
+            reader.nextRow()
+
+        assertAll(
+            { assertTrue(reader.nextRow()) },
+            { assertEquals("0", reader.get(TASK_WORKFLOW_ID)) },
+            { assertEquals("7", reader.get(TASK_ID)) },
+            { assertEquals(Instant.ofEpochSecond(87), reader.get(TASK_SUBMIT_TIME)) },
+            { assertEquals(Duration.ofSeconds(11), reader.get(TASK_RUNTIME)) },
+            { assertEquals(setOf<String>("4", "5", "6"), reader.get(TASK_PARENTS)) },
+        )
+    }
 }

--- a/opendc-workflow/opendc-workflow-service/src/test/kotlin/org/opendc/workflow/service/WorkflowServiceTest.kt
+++ b/opendc-workflow/opendc-workflow-service/src/test/kotlin/org/opendc/workflow/service/WorkflowServiceTest.kt
@@ -104,7 +104,7 @@ internal class WorkflowServiceTest {
             { assertEquals(metrics.jobsSubmitted, metrics.jobsFinished, "Not all started jobs finished") },
             { assertEquals(0, metrics.tasksActive, "Not all started tasks finished") },
             { assertEquals(metrics.tasksSubmitted, metrics.tasksFinished, "Not all started tasks finished") },
-            { assertEquals(33214236L, clock.millis()) { "Total duration incorrect" } }
+            { assertEquals(32649883L, clock.millis()) { "Total duration incorrect" } }
         )
     }
 


### PR DESCRIPTION
## Summary

When reading from a .gwf trace file, tasks now have (or are) dependencies.

## Implementation Notes :hammer_and_pick:

Tasks from a .gwf trace file did not have dependencies because the `dependencies` property of `GwfTaskTableReader` was not assigned after the column has been read.

I removed the conversion from `String` to `Long` in `parseParents` because it seems like other readers (the Parquet reader in particular) return `String`s as well, which is why they are converted to `Long` in line 75 of _TraceHelpers.kt_.

https://github.com/atlarge-research/opendc/blob/a921c9f847aabe72bdef42574d96f905d9fb2468/opendc-workflow/opendc-workflow-workload/src/main/kotlin/org/opendc/workflow/workload/TraceHelpers.kt#L75