### PR TITLE
Update OpenTelemetry to version 1.11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,9 +12,9 @@ kotlinx-coroutines = "1.6.0"
 ktor = "1.6.7"
 log4j = "2.17.1"
 mockk = "1.12.2"
-opentelemetry-main = "1.6.0"
-opentelemetry-metrics = "1.6.0-alpha"
-opentelemetry-semconv = "1.6.0-alpha"
+opentelemetry-main = "1.11.0"
+opentelemetry-metrics = "1.10.1-alpha"
+opentelemetry-semconv = "1.10.1-alpha"
 parquet = "1.12.2"
 progressbar = "0.9.2"
 sentry = "5.5.2"
@@ -31,9 +31,8 @@ log4j-slf4j = { module = "org.apache.logging.log4j:log4j-slf4j-impl", version.re
 sentry-log4j2 = { module = "io.sentry:sentry-log4j2", version.ref = "sentry" }
 
 # Telemetry
-opentelemetry-api-main = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry-main" }
+opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry-main" }
 opentelemetry-sdk-main = { module = "io.opentelemetry:opentelemetry-sdk", version.ref = "opentelemetry-main" }
-opentelemetry-api-metrics = { module = "io.opentelemetry:opentelemetry-api-metrics", version.ref = "opentelemetry-metrics" }
 opentelemetry-sdk-metrics = { module = "io.opentelemetry:opentelemetry-sdk-metrics", version.ref = "opentelemetry-metrics" }
 opentelemetry-semconv = { module = "io.opentelemetry:opentelemetry-semconv", version.ref = "opentelemetry-semconv" }
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
@@ -150,15 +150,15 @@ public class SimHost(
         meter.gaugeBuilder("system.cpu.demand")
             .setDescription("Amount of CPU resources the guests would use if there were no CPU contention or CPU limits")
             .setUnit("MHz")
-            .buildWithCallback { result -> result.observe(hypervisor.cpuDemand) }
+            .buildWithCallback { result -> result.record(hypervisor.cpuDemand) }
         meter.gaugeBuilder("system.cpu.usage")
             .setDescription("Amount of CPU resources used by the host")
             .setUnit("MHz")
-            .buildWithCallback { result -> result.observe(hypervisor.cpuUsage) }
+            .buildWithCallback { result -> result.record(hypervisor.cpuUsage) }
         meter.gaugeBuilder("system.cpu.utilization")
             .setDescription("Utilization of the CPU resources of the host")
             .setUnit("%")
-            .buildWithCallback { result -> result.observe(hypervisor.cpuUsage / _cpuLimit) }
+            .buildWithCallback { result -> result.record(hypervisor.cpuUsage / _cpuLimit) }
         meter.counterBuilder("system.cpu.time")
             .setDescription("Amount of CPU time spent by the host")
             .setUnit("s")
@@ -166,12 +166,12 @@ public class SimHost(
         meter.gaugeBuilder("system.power.usage")
             .setDescription("Power usage of the host ")
             .setUnit("W")
-            .buildWithCallback { result -> result.observe(machine.powerUsage) }
+            .buildWithCallback { result -> result.record(machine.powerUsage) }
         meter.counterBuilder("system.power.total")
             .setDescription("Amount of energy used by the CPU")
             .setUnit("J")
             .ofDoubles()
-            .buildWithCallback { result -> result.observe(machine.energyUsage) }
+            .buildWithCallback { result -> result.record(machine.energyUsage) }
         meter.counterBuilder("system.time")
             .setDescription("The uptime of the host")
             .setUnit("s")
@@ -382,10 +382,10 @@ public class SimHost(
             }
         }
 
-        result.observe(terminated, terminatedState)
-        result.observe(running, runningState)
-        result.observe(error, errorState)
-        result.observe(invalid, invalidState)
+        result.record(terminated, terminatedState)
+        result.record(running, runningState)
+        result.record(error, errorState)
+        result.record(invalid, invalidState)
     }
 
     private val _cpuLimit = machine.model.cpus.sumOf { it.frequency }
@@ -394,7 +394,7 @@ public class SimHost(
      * Helper function to collect the CPU limits of a machine.
      */
     private fun collectCpuLimit(result: ObservableDoubleMeasurement) {
-        result.observe(_cpuLimit)
+        result.record(_cpuLimit)
 
         val guests = _guests
         for (i in guests.indices) {
@@ -413,10 +413,10 @@ public class SimHost(
     private fun collectCpuTime(result: ObservableLongMeasurement) {
         val counters = hypervisor.counters
 
-        result.observe(counters.cpuActiveTime / 1000L, _activeState)
-        result.observe(counters.cpuIdleTime / 1000L, _idleState)
-        result.observe(counters.cpuStealTime / 1000L, _stealState)
-        result.observe(counters.cpuLostTime / 1000L, _lostState)
+        result.record(counters.cpuActiveTime / 1000L, _activeState)
+        result.record(counters.cpuIdleTime / 1000L, _idleState)
+        result.record(counters.cpuStealTime / 1000L, _stealState)
+        result.record(counters.cpuLostTime / 1000L, _lostState)
 
         val guests = _guests
         for (i in guests.indices) {
@@ -458,8 +458,8 @@ public class SimHost(
     private fun collectUptime(result: ObservableLongMeasurement) {
         updateUptime()
 
-        result.observe(_uptime, _upState)
-        result.observe(_downtime, _downState)
+        result.record(_uptime, _upState)
+        result.record(_downtime, _downState)
 
         val guests = _guests
         for (i in guests.indices) {
@@ -474,7 +474,7 @@ public class SimHost(
      */
     private fun collectBootTime(result: ObservableLongMeasurement) {
         if (_bootTime != Long.MIN_VALUE) {
-            result.observe(_bootTime)
+            result.record(_bootTime)
         }
 
         val guests = _guests

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/internal/Guest.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/internal/Guest.kt
@@ -239,8 +239,8 @@ internal class Guest(
      * Helper function to track the uptime of the guest.
      */
     fun collectUptime(result: ObservableLongMeasurement) {
-        result.observe(_uptime, _upState)
-        result.observe(_downtime, _downState)
+        result.record(_uptime, _upState)
+        result.record(_downtime, _downState)
     }
 
     private var _bootTime = Long.MIN_VALUE
@@ -250,7 +250,7 @@ internal class Guest(
      */
     fun collectBootTime(result: ObservableLongMeasurement) {
         if (_bootTime != Long.MIN_VALUE) {
-            result.observe(_bootTime, attributes)
+            result.record(_bootTime, attributes)
         }
     }
 
@@ -273,10 +273,10 @@ internal class Guest(
     fun collectCpuTime(result: ObservableLongMeasurement) {
         val counters = machine.counters
 
-        result.observe(counters.cpuActiveTime / 1000, _activeState)
-        result.observe(counters.cpuIdleTime / 1000, _idleState)
-        result.observe(counters.cpuStealTime / 1000, _stealState)
-        result.observe(counters.cpuLostTime / 1000, _lostState)
+        result.record(counters.cpuActiveTime / 1000, _activeState)
+        result.record(counters.cpuIdleTime / 1000, _idleState)
+        result.record(counters.cpuStealTime / 1000, _stealState)
+        result.record(counters.cpuLostTime / 1000, _lostState)
     }
 
     private val _cpuLimit = machine.model.cpus.sumOf { it.frequency }
@@ -285,7 +285,7 @@ internal class Guest(
      * Helper function to collect the CPU limits of a machine.
      */
     fun collectCpuLimit(result: ObservableDoubleMeasurement) {
-        result.observe(_cpuLimit, attributes)
+        result.record(_cpuLimit, attributes)
     }
 
     /**

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/telemetry/NoopTelemetryManager.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/telemetry/NoopTelemetryManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 AtLarge Research
+ * Copyright (c) 2022 AtLarge Research
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,14 +20,17 @@
  * SOFTWARE.
  */
 
-description = "Telemetry API for OpenDC"
+package org.opendc.compute.workload.telemetry
 
-/* Build configuration */
-plugins {
-    `kotlin-library-conventions`
-}
+import io.opentelemetry.api.metrics.MeterProvider
+import org.opendc.compute.service.scheduler.ComputeScheduler
+import org.opendc.compute.workload.topology.HostSpec
 
-dependencies {
-    api(platform(projects.opendcPlatform))
-    api(libs.opentelemetry.api)
+/**
+ * A [TelemetryManager] that does nothing.
+ */
+public class NoopTelemetryManager : TelemetryManager {
+    override fun createMeterProvider(host: HostSpec): MeterProvider = MeterProvider.noop()
+
+    override fun createMeterProvider(scheduler: ComputeScheduler): MeterProvider = MeterProvider.noop()
 }

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/telemetry/SdkTelemetryManager.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/telemetry/SdkTelemetryManager.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 AtLarge Research
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package org.opendc.compute.workload.telemetry
+
+import io.opentelemetry.api.metrics.MeterProvider
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.metrics.export.MetricProducer
+import io.opentelemetry.sdk.metrics.export.MetricReader
+import io.opentelemetry.sdk.metrics.export.MetricReaderFactory
+import io.opentelemetry.sdk.resources.Resource
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
+import org.opendc.compute.service.scheduler.ComputeScheduler
+import org.opendc.compute.workload.topology.HostSpec
+import org.opendc.telemetry.compute.*
+import org.opendc.telemetry.sdk.toOtelClock
+import java.time.Clock
+
+/**
+ * A [TelemetryManager] using the OpenTelemetry Java SDK.
+ */
+public class SdkTelemetryManager(private val clock: Clock) : TelemetryManager, AutoCloseable {
+    /**
+     * The [SdkMeterProvider]s that belong to the workload runner.
+     */
+    private val _meterProviders = mutableListOf<SdkMeterProvider>()
+
+    /**
+     * The internal [MetricProducer] registered with the runner.
+     */
+    private val _metricProducers = mutableListOf<MetricProducer>()
+
+    /**
+     * The list of [MetricReader]s that have been registered with the runner.
+     */
+    private val _metricReaders = mutableListOf<MetricReader>()
+
+    /**
+     * A [MetricProducer] that combines all the other metric producers.
+     */
+    public val metricProducer: MetricProducer = object : MetricProducer {
+        private val producers = _metricProducers
+
+        override fun collectAllMetrics(): Collection<MetricData> = producers.flatMap(MetricProducer::collectAllMetrics)
+
+        override fun toString(): String = "SdkTelemetryManager.AggregateMetricProducer"
+    }
+
+    /**
+     * Register a [MetricReader] for this manager.
+     *
+     * @param factory The factory for the reader to register.
+     */
+    public fun registerMetricReader(factory: MetricReaderFactory) {
+        val reader = factory.apply(metricProducer)
+        _metricReaders.add(reader)
+    }
+
+    override fun createMeterProvider(scheduler: ComputeScheduler): MeterProvider {
+        val resource = Resource.builder()
+            .put(ResourceAttributes.SERVICE_NAME, "opendc-compute")
+            .build()
+
+        return createMeterProvider(resource)
+    }
+
+    override fun createMeterProvider(host: HostSpec): MeterProvider {
+        val resource = Resource.builder()
+            .put(HOST_ID, host.uid.toString())
+            .put(HOST_NAME, host.name)
+            .put(HOST_ARCH, ResourceAttributes.HostArchValues.AMD64)
+            .put(HOST_NCPUS, host.model.cpus.size)
+            .put(HOST_MEM_CAPACITY, host.model.memory.sumOf { it.size })
+            .build()
+
+        return createMeterProvider(resource)
+    }
+
+    /**
+     * Construct a [SdkMeterProvider] for the specified [resource].
+     */
+    private fun createMeterProvider(resource: Resource): SdkMeterProvider {
+        val meterProvider = SdkMeterProvider.builder()
+            .setClock(clock.toOtelClock())
+            .setResource(resource)
+            .registerMetricReader { producer ->
+                _metricProducers.add(producer)
+                object : MetricReader {
+                    override fun getPreferredTemporality(): AggregationTemporality = AggregationTemporality.CUMULATIVE
+                    override fun flush(): CompletableResultCode = CompletableResultCode.ofSuccess()
+                    override fun shutdown(): CompletableResultCode = CompletableResultCode.ofSuccess()
+                }
+            }
+            .build()
+        _meterProviders.add(meterProvider)
+        return meterProvider
+    }
+
+    override fun close() {
+        for (meterProvider in _meterProviders) {
+            meterProvider.close()
+        }
+
+        _meterProviders.clear()
+
+        for (metricReader in _metricReaders) {
+            metricReader.shutdown()
+        }
+
+        _metricReaders.clear()
+        _metricProducers.clear()
+    }
+}

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/telemetry/TelemetryManager.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/telemetry/TelemetryManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 AtLarge Research
+ * Copyright (c) 2022 AtLarge Research
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,14 +20,23 @@
  * SOFTWARE.
  */
 
-description = "Telemetry API for OpenDC"
+package org.opendc.compute.workload.telemetry
 
-/* Build configuration */
-plugins {
-    `kotlin-library-conventions`
-}
+import io.opentelemetry.api.metrics.MeterProvider
+import org.opendc.compute.service.scheduler.ComputeScheduler
+import org.opendc.compute.workload.topology.HostSpec
 
-dependencies {
-    api(platform(projects.opendcPlatform))
-    api(libs.opentelemetry.api)
+/**
+ * Helper class to manage the telemetry for a [ComputeServiceHelper] instance.
+ */
+public interface TelemetryManager {
+    /**
+     * Construct a [MeterProvider] for the specified [ComputeScheduler].
+     */
+    public fun createMeterProvider(scheduler: ComputeScheduler): MeterProvider
+
+    /**
+     * Construct a [MeterProvider] for the specified [HostSpec].
+     */
+    public fun createMeterProvider(host: HostSpec): MeterProvider
 }

--- a/opendc-experiments/opendc-experiments-capelin/src/jmh/kotlin/org/opendc/experiments/capelin/CapelinBenchmarks.kt
+++ b/opendc-experiments/opendc-experiments-capelin/src/jmh/kotlin/org/opendc/experiments/capelin/CapelinBenchmarks.kt
@@ -29,6 +29,7 @@ import org.opendc.compute.service.scheduler.filters.RamFilter
 import org.opendc.compute.service.scheduler.filters.VCpuFilter
 import org.opendc.compute.service.scheduler.weights.CoreRamWeigher
 import org.opendc.compute.workload.*
+import org.opendc.compute.workload.telemetry.NoopTelemetryManager
 import org.opendc.compute.workload.topology.Topology
 import org.opendc.compute.workload.topology.apply
 import org.opendc.experiments.capelin.topology.clusterTopology
@@ -70,6 +71,7 @@ class CapelinBenchmarks {
         val runner = ComputeServiceHelper(
             coroutineContext,
             clock,
+            NoopTelemetryManager(),
             computeScheduler
         )
 

--- a/opendc-experiments/opendc-experiments-capelin/src/main/kotlin/org/opendc/experiments/capelin/Portfolio.kt
+++ b/opendc-experiments/opendc-experiments-capelin/src/main/kotlin/org/opendc/experiments/capelin/Portfolio.kt
@@ -29,6 +29,7 @@ import org.opendc.compute.workload.ComputeWorkloadLoader
 import org.opendc.compute.workload.createComputeScheduler
 import org.opendc.compute.workload.export.parquet.ParquetComputeMetricExporter
 import org.opendc.compute.workload.grid5000
+import org.opendc.compute.workload.telemetry.SdkTelemetryManager
 import org.opendc.compute.workload.topology.apply
 import org.opendc.compute.workload.util.VmInterferenceModelReader
 import org.opendc.experiments.capelin.model.OperationalPhenomena
@@ -38,7 +39,6 @@ import org.opendc.experiments.capelin.topology.clusterTopology
 import org.opendc.harness.dsl.Experiment
 import org.opendc.harness.dsl.anyOf
 import org.opendc.simulator.core.runBlockingSimulation
-import org.opendc.telemetry.compute.collectServiceMetrics
 import org.opendc.telemetry.sdk.metrics.export.CoroutineMetricReader
 import java.io.File
 import java.time.Duration
@@ -109,9 +109,11 @@ abstract class Portfolio(name: String) : Experiment(name) {
                 grid5000(Duration.ofSeconds((operationalPhenomena.failureFrequency * 60).roundToLong()))
             else
                 null
+        val telemetry = SdkTelemetryManager(clock)
         val runner = ComputeServiceHelper(
             coroutineContext,
             clock,
+            telemetry,
             computeScheduler,
             failureModel,
             performanceInterferenceModel?.withSeed(repeat.toLong())
@@ -122,7 +124,8 @@ abstract class Portfolio(name: String) : Experiment(name) {
             "portfolio_id=$name/scenario_id=$id/run_id=$repeat",
             4096
         )
-        val metricReader = CoroutineMetricReader(this, runner.producers, exporter)
+        telemetry.registerMetricReader(CoroutineMetricReader(this, exporter))
+
         val topology = clusterTopology(File(config.getString("env-path"), "${topology.name}.txt"))
 
         try {
@@ -133,17 +136,6 @@ abstract class Portfolio(name: String) : Experiment(name) {
             runner.run(workload.source.resolve(workloadLoader, seeder), seeder.nextLong())
         } finally {
             runner.close()
-            metricReader.close()
-        }
-
-        val monitorResults = collectServiceMetrics(runner.producers[0])
-        logger.debug {
-            "Scheduler " +
-                "Success=${monitorResults.attemptsSuccess} " +
-                "Failure=${monitorResults.attemptsFailure} " +
-                "Error=${monitorResults.attemptsError} " +
-                "Pending=${monitorResults.serversPending} " +
-                "Active=${monitorResults.serversActive}"
         }
     }
 }

--- a/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/SimTFDevice.kt
+++ b/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/SimTFDevice.kt
@@ -23,7 +23,6 @@
 package org.opendc.experiments.tf20.core
 
 import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.Meter
 import kotlinx.coroutines.*
 import org.opendc.simulator.compute.SimBareMetalMachine
@@ -82,7 +81,6 @@ public class SimTFDevice(
         .setDescription("The amount of device resources used")
         .setUnit("MHz")
         .build()
-        .bind(Attributes.of(deviceId, uid.toString()))
 
     /**
      * The power draw of the device.
@@ -91,7 +89,6 @@ public class SimTFDevice(
         .setDescription("The power draw of the device")
         .setUnit("W")
         .build()
-        .bind(Attributes.of(deviceId, uid.toString()))
 
     /**
      * The workload that will be run by the device.

--- a/opendc-faas/opendc-faas-service/src/main/kotlin/org/opendc/faas/service/FunctionObject.kt
+++ b/opendc-faas/opendc-faas-service/src/main/kotlin/org/opendc/faas/service/FunctionObject.kt
@@ -24,9 +24,9 @@ package org.opendc.faas.service
 
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.metrics.BoundLongCounter
-import io.opentelemetry.api.metrics.BoundLongHistogram
-import io.opentelemetry.api.metrics.BoundLongUpDownCounter
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.LongHistogram
+import io.opentelemetry.api.metrics.LongUpDownCounter
 import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes
 import org.opendc.faas.service.deployer.FunctionInstance
@@ -56,76 +56,68 @@ public class FunctionObject(
     /**
      * The total amount of function invocations received by the function.
      */
-    public val invocations: BoundLongCounter = meter.counterBuilder("function.invocations.total")
+    public val invocations: LongCounter = meter.counterBuilder("function.invocations.total")
         .setDescription("Number of function invocations")
         .setUnit("1")
         .build()
-        .bind(attributes)
 
     /**
      * The amount of function invocations that could be handled directly.
      */
-    public val timelyInvocations: BoundLongCounter = meter.counterBuilder("function.invocations.warm")
+    public val timelyInvocations: LongCounter = meter.counterBuilder("function.invocations.warm")
         .setDescription("Number of function invocations handled directly")
         .setUnit("1")
         .build()
-        .bind(attributes)
 
     /**
      * The amount of function invocations that were delayed due to function deployment.
      */
-    public val delayedInvocations: BoundLongCounter = meter.counterBuilder("function.invocations.cold")
+    public val delayedInvocations: LongCounter = meter.counterBuilder("function.invocations.cold")
         .setDescription("Number of function invocations that are delayed")
         .setUnit("1")
         .build()
-        .bind(attributes)
 
     /**
      * The amount of function invocations that failed.
      */
-    public val failedInvocations: BoundLongCounter = meter.counterBuilder("function.invocations.failed")
+    public val failedInvocations: LongCounter = meter.counterBuilder("function.invocations.failed")
         .setDescription("Number of function invocations that failed")
         .setUnit("1")
         .build()
-        .bind(attributes)
 
     /**
      * The amount of instances for this function.
      */
-    public val activeInstances: BoundLongUpDownCounter = meter.upDownCounterBuilder("function.instances.active")
+    public val activeInstances: LongUpDownCounter = meter.upDownCounterBuilder("function.instances.active")
         .setDescription("Number of active function instances")
         .setUnit("1")
         .build()
-        .bind(attributes)
 
     /**
      * The amount of idle instances for this function.
      */
-    public val idleInstances: BoundLongUpDownCounter = meter.upDownCounterBuilder("function.instances.idle")
+    public val idleInstances: LongUpDownCounter = meter.upDownCounterBuilder("function.instances.idle")
         .setDescription("Number of idle function instances")
         .setUnit("1")
         .build()
-        .bind(attributes)
 
     /**
      * The time that the function waited.
      */
-    public val waitTime: BoundLongHistogram = meter.histogramBuilder("function.time.wait")
+    public val waitTime: LongHistogram = meter.histogramBuilder("function.time.wait")
         .ofLongs()
         .setDescription("Time the function has to wait before being started")
         .setUnit("ms")
         .build()
-        .bind(attributes)
 
     /**
      * The time that the function was running.
      */
-    public val activeTime: BoundLongHistogram = meter.histogramBuilder("function.time.active")
+    public val activeTime: LongHistogram = meter.histogramBuilder("function.time.active")
         .ofLongs()
         .setDescription("Time the function was running")
         .setUnit("ms")
         .build()
-        .bind(attributes)
 
     /**
      * The instances associated with this function.

--- a/opendc-workflow/opendc-workflow-service/src/test/kotlin/org/opendc/workflow/service/WorkflowServiceTest.kt
+++ b/opendc-workflow/opendc-workflow-service/src/test/kotlin/org/opendc/workflow/service/WorkflowServiceTest.kt
@@ -33,6 +33,7 @@ import org.opendc.compute.service.scheduler.filters.RamFilter
 import org.opendc.compute.service.scheduler.filters.VCpuFilter
 import org.opendc.compute.service.scheduler.weights.VCpuWeigher
 import org.opendc.compute.workload.ComputeServiceHelper
+import org.opendc.compute.workload.telemetry.NoopTelemetryManager
 import org.opendc.compute.workload.topology.HostSpec
 import org.opendc.simulator.compute.kernel.SimSpaceSharedHypervisorProvider
 import org.opendc.simulator.compute.model.MachineModel
@@ -70,7 +71,8 @@ internal class WorkflowServiceTest {
             filters = listOf(ComputeFilter(), VCpuFilter(1.0), RamFilter(1.0)),
             weighers = listOf(VCpuWeigher(1.0, multiplier = 1.0))
         )
-        val computeHelper = ComputeServiceHelper(coroutineContext, clock, computeScheduler, schedulingQuantum = Duration.ofSeconds(1))
+
+        val computeHelper = ComputeServiceHelper(coroutineContext, clock, NoopTelemetryManager(), computeScheduler, schedulingQuantum = Duration.ofSeconds(1))
 
         repeat(HOST_COUNT) { computeHelper.registerHost(createHostSpec(it)) }
 


### PR DESCRIPTION
## Summary

This change updates the OpenDC codebase to use OpenTelemetry v1.11, which stabilizes the metrics API. 
This stabilization brings quite a few breaking changes, so significant changes are necessary inside the OpenDC
codebase.

## Implementation Notes :hammer_and_pick:

* Upgrade to OpenTelemetry v1.11.0
* Add TelemetryManager interface to abstract OpenTelemetry implementation

## External Dependencies :four_leaf_clover:

* OpenTelemetry v1.11.0

## Breaking API Changes :warning:

* Telemetry is not directly exposed by the service helpers, but instead via the `TelemetryManager` interface.