### PR TITLE
Fix distributed strategy for TensorFlow experiment

### DIFF
--- a/opendc-experiments/opendc-experiments-capelin/src/test/kotlin/org/opendc/experiments/capelin/CapelinIntegrationTest.kt
+++ b/opendc-experiments/opendc-experiments-capelin/src/test/kotlin/org/opendc/experiments/capelin/CapelinIntegrationTest.kt
@@ -116,7 +116,7 @@ class CapelinIntegrationTest {
                 { assertEquals(66977508, this@CapelinIntegrationTest.monitor.activeTime) { "Incorrect active time" } },
                 { assertEquals(3160381, this@CapelinIntegrationTest.monitor.stealTime) { "Incorrect steal time" } },
                 { assertEquals(0, this@CapelinIntegrationTest.monitor.lostTime) { "Incorrect lost time" } },
-                { assertEquals(5.840845430827075E9, this@CapelinIntegrationTest.monitor.energyUsage, 0.01) { "Incorrect power draw" } },
+                { assertEquals(5.840939264814157E9, this@CapelinIntegrationTest.monitor.energyUsage, 0.01) { "Incorrect power draw" } },
             )
         } finally {
             runner.close()
@@ -164,7 +164,7 @@ class CapelinIntegrationTest {
             { assertEquals(9741207, this@CapelinIntegrationTest.monitor.activeTime) { "Active time incorrect" } },
             { assertEquals(0, this@CapelinIntegrationTest.monitor.stealTime) { "Steal time incorrect" } },
             { assertEquals(0, this@CapelinIntegrationTest.monitor.lostTime) { "Lost time incorrect" } },
-            { assertEquals(7.011413569311495E8, this@CapelinIntegrationTest.monitor.energyUsage, 0.01) { "Incorrect power draw" } }
+            { assertEquals(7.011676470304312E8, this@CapelinIntegrationTest.monitor.energyUsage, 0.01) { "Incorrect power draw" } }
         )
     }
 

--- a/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/SimTFDevice.kt
+++ b/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/SimTFDevice.kt
@@ -68,13 +68,6 @@ public class SimTFDevice(
     )
 
     /**
-     * Metrics collected by the device.
-     */
-    private var _resourceUsage = 0.0
-    private var _powerUsage = 0.0
-    private var _energyUsage = 0.0
-
-    /**
      * The workload that will be run by the device.
      */
     private val workload = object : SimWorkload, FlowSource {
@@ -121,7 +114,7 @@ public class SimTFDevice(
             ctx = conn
             capacity = conn.capacity
             lastPull = now
-            conn.shouldSourceConverge = true
+            conn.shouldSourceConverge = false
         }
 
         override fun onPull(conn: FlowConnection, now: Long): Long {
@@ -156,12 +149,6 @@ public class SimTFDevice(
                 Long.MAX_VALUE
             }
         }
-
-        override fun onConverge(conn: FlowConnection, now: Long) {
-            _resourceUsage = conn.rate
-            _powerUsage = machine.powerUsage
-            _energyUsage = machine.energyUsage
-        }
     }
 
     init {
@@ -183,7 +170,8 @@ public class SimTFDevice(
     }
 
     override fun getDeviceStats(): TFDeviceStats {
-        return TFDeviceStats(_resourceUsage, _powerUsage, _energyUsage)
+        val resourceUsage = machine.cpus.sumOf { it.rate }
+        return TFDeviceStats(resourceUsage, machine.powerUsage, machine.energyUsage)
     }
 
     override fun close() {

--- a/opendc-experiments/opendc-experiments-tf20/src/test/kotlin/org/opendc/experiments/tf20/core/SimTFDeviceTest.kt
+++ b/opendc-experiments/opendc-experiments-tf20/src/test/kotlin/org/opendc/experiments/tf20/core/SimTFDeviceTest.kt
@@ -69,7 +69,7 @@ internal class SimTFDeviceTest {
 
         assertAll(
             { assertEquals(3681, clock.millis()) },
-            { assertEquals(325.75, stats.energyUsage) }
+            { assertEquals(749.25, stats.energyUsage) }
         )
     }
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/kotlin/org/opendc/simulator/compute/SimBareMetalMachine.kt
+++ b/opendc-simulator/opendc-simulator-compute/src/main/kotlin/org/opendc/simulator/compute/SimBareMetalMachine.kt
@@ -91,8 +91,9 @@ public class SimBareMetalMachine(
         if (duration > 0) {
             // Compute the power and energy usage of the machine
             computeEnergyUsage(now)
-            _powerUsage = powerDriverLogic.computePower()
         }
+
+        _powerUsage = powerDriverLogic.computePower()
     }
 
     init {

--- a/opendc-simulator/opendc-simulator-compute/src/main/kotlin/org/opendc/simulator/compute/workload/SimTrace.kt
+++ b/opendc-simulator/opendc-simulator-compute/src/main/kotlin/org/opendc/simulator/compute/workload/SimTrace.kt
@@ -55,6 +55,7 @@ public class SimTrace(
         /**
          * Construct a [SimTrace] with the specified fragments.
          */
+        @JvmStatic
         public fun ofFragments(fragments: List<SimTraceFragment>): SimTrace {
             val size = fragments.size
             val usageCol = DoubleArray(size)
@@ -180,7 +181,7 @@ public class SimTrace(
          */
         private fun grow() {
             val arraySize = usageCol.size
-            val newSize = arraySize * 2
+            val newSize = arraySize + (arraySize shr 1)
 
             usageCol = usageCol.copyOf(newSize)
             timestampCol = timestampCol.copyOf(newSize)


### PR DESCRIPTION
## Summary

This pull request fixes an issue where the distributed strategies for the TensorFlow experiments did not work correctly.

## Implementation Notes :hammer_and_pick:

* Limit growth rate for trace construction
* Derive device statistics directly from SimMachine 
* Always recompute power usage when a `SImBareMetalMachine` converges
* Add a test case for `MirroredStrategy`

## External Dependencies :four_leaf_clover:

*  N/A

## Breaking API Changes :warning:

* N/A