### PR TITLE
Support snapshotting simulated workloads

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
@@ -280,7 +280,7 @@ public class SimHost(
 
         val bootWorkload = bootModel.get()
         val hypervisor = hypervisor
-        val hypervisorWorkload = object : SimWorkload {
+        val hypervisorWorkload = object : SimWorkload by hypervisor {
             override fun onStart(ctx: SimMachineContext) {
                 try {
                     _bootTime = clock.instant()
@@ -295,10 +295,6 @@ public class SimHost(
                     _state = HostState.ERROR
                     throw cause
                 }
-            }
-
-            override fun onStop(ctx: SimMachineContext) {
-                hypervisor.onStop(ctx)
             }
         }
 

--- a/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/SimTFDevice.kt
+++ b/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/SimTFDevice.kt
@@ -127,6 +127,8 @@ public class SimTFDevice(
             output = null
         }
 
+        override fun snapshot(): SimWorkload = throw UnsupportedOperationException()
+
         override fun onUpdate(ctx: FlowStage, now: Long): Long {
             val output = output ?: return Long.MAX_VALUE
             val lastPull = lastPull

--- a/opendc-simulator/opendc-simulator-compute/build.gradle.kts
+++ b/opendc-simulator/opendc-simulator-compute/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     api(projects.opendcSimulator.opendcSimulatorPower)
     api(projects.opendcSimulator.opendcSimulatorNetwork)
     implementation(projects.opendcSimulator.opendcSimulatorCore)
-    implementation(libs.kotlin.logging)
 
     testImplementation(libs.slf4j.simple)
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimAbstractMachine.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimAbstractMachine.java
@@ -131,6 +131,11 @@ public abstract class SimAbstractMachine implements SimMachine {
         }
 
         @Override
+        public SimWorkload snapshot() {
+            return workload.snapshot();
+        }
+
+        @Override
         public void reset() {
             final FlowGraph graph = getMemory().getInput().getGraph();
 

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimMachineContext.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimMachineContext.java
@@ -69,6 +69,13 @@ public interface SimMachineContext {
     List<? extends SimStorageInterface> getStorageInterfaces();
 
     /**
+     * Create a snapshot of the {@link SimWorkload} running on this machine.
+     *
+     * @throws UnsupportedOperationException if the workload does not support snapshotting.
+     */
+    SimWorkload snapshot();
+
+    /**
      * Reset all resources of the machine.
      */
     void reset();

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimMachineContext.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimMachineContext.java
@@ -24,6 +24,7 @@ package org.opendc.simulator.compute;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.opendc.simulator.compute.workload.SimWorkload;
 import org.opendc.simulator.flow2.FlowGraph;
 
@@ -43,7 +44,7 @@ public interface SimMachineContext {
     /**
      * Return the metadata associated with the context.
      * <p>
-     * Users can pass this metadata to the workload via {@link SimMachine#startWorkload(SimWorkload, Map)}.
+     * Users can pass this metadata to the workload via {@link SimMachine#startWorkload(SimWorkload, Map, Consumer)}.
      */
     Map<String, Object> getMeta();
 
@@ -76,4 +77,11 @@ public interface SimMachineContext {
      * Shutdown the workload.
      */
     void shutdown();
+
+    /**
+     * Shutdown the workload due to failure.
+     *
+     * @param cause The cause for shutting down the workload.
+     */
+    void shutdown(Exception cause);
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/kernel/SimHypervisor.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/kernel/SimHypervisor.java
@@ -240,6 +240,11 @@ public final class SimHypervisor implements SimWorkload {
         }
     }
 
+    @Override
+    public SimWorkload snapshot() {
+        throw new UnsupportedOperationException("Unable to snapshot hypervisor");
+    }
+
     /**
      * The context which carries the state when the hypervisor is running on a machine.
      */

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimChainWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimChainWorkload.java
@@ -44,9 +44,20 @@ final class SimChainWorkload implements SimWorkload {
      * Construct a {@link SimChainWorkload} instance.
      *
      * @param workloads The workloads to chain.
+     * @param activeWorkloadIndex The index of the active workload.
+     */
+    SimChainWorkload(SimWorkload[] workloads, int activeWorkloadIndex) {
+        this.workloads = workloads;
+        this.activeWorkloadIndex = activeWorkloadIndex;
+    }
+
+    /**
+     * Construct a {@link SimChainWorkload} instance.
+     *
+     * @param workloads The workloads to chain.
      */
     SimChainWorkload(SimWorkload... workloads) {
-        this.workloads = workloads;
+        this(workloads, 0);
     }
 
     @Override
@@ -77,6 +88,19 @@ final class SimChainWorkload implements SimWorkload {
         activeContext = null;
 
         tryThrow(context.doStop(workloads[activeWorkloadIndex]));
+    }
+
+    @Override
+    public SimChainWorkload snapshot() {
+        final int activeWorkloadIndex = this.activeWorkloadIndex;
+        final SimWorkload[] workloads = this.workloads;
+        final SimWorkload[] newWorkloads = new SimWorkload[workloads.length - activeWorkloadIndex];
+
+        for (int i = 0; i < newWorkloads.length; i++) {
+            newWorkloads[i] = workloads[activeWorkloadIndex + i].snapshot();
+        }
+
+        return new SimChainWorkload(newWorkloads, 0);
     }
 
     /**
@@ -117,6 +141,12 @@ final class SimChainWorkload implements SimWorkload {
         @Override
         public List<? extends SimStorageInterface> getStorageInterfaces() {
             return ctx.getStorageInterfaces();
+        }
+
+        @Override
+        public SimWorkload snapshot() {
+            final SimWorkload workload = workloads[activeWorkloadIndex];
+            return workload.snapshot();
         }
 
         @Override

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimFlopsWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimFlopsWorkload.java
@@ -60,6 +60,7 @@ public class SimFlopsWorkload implements SimWorkload, FlowStageLogic {
 
         this.flops = flops;
         this.utilization = utilization;
+        this.remainingAmount = flops;
     }
 
     @Override
@@ -98,8 +99,13 @@ public class SimFlopsWorkload implements SimWorkload, FlowStageLogic {
     }
 
     @Override
-    public String toString() {
-        return "SimFlopsWorkload[FLOPs=" + flops + ",utilization=" + utilization + "]";
+    public SimFlopsWorkload snapshot() {
+        final FlowStage stage = this.stage;
+        if (stage != null) {
+            stage.sync();
+        }
+
+        return new SimFlopsWorkload((long) remainingAmount, utilization);
     }
 
     @Override
@@ -137,5 +143,10 @@ public class SimFlopsWorkload implements SimWorkload, FlowStageLogic {
         }
 
         return now + duration;
+    }
+
+    @Override
+    public String toString() {
+        return "SimFlopsWorkload[FLOPs=" + flops + ",utilization=" + utilization + "]";
     }
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimRuntimeWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimRuntimeWorkload.java
@@ -59,6 +59,7 @@ public class SimRuntimeWorkload implements SimWorkload, FlowStageLogic {
 
         this.duration = duration;
         this.utilization = utilization;
+        this.remainingDuration = duration;
     }
 
     @Override
@@ -95,6 +96,16 @@ public class SimRuntimeWorkload implements SimWorkload, FlowStageLogic {
             this.outputs = null;
             stage.close();
         }
+    }
+
+    @Override
+    public SimRuntimeWorkload snapshot() {
+        final FlowStage stage = this.stage;
+        if (stage != null) {
+            stage.sync();
+        }
+
+        return new SimRuntimeWorkload(remainingDuration, utilization);
     }
 
     @Override

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimWorkload.java
@@ -45,4 +45,9 @@ public interface SimWorkload {
      * @param ctx The execution context in which the machine runs.
      */
     void onStop(SimMachineContext ctx);
+
+    /**
+     * Create a snapshot of this workload.
+     */
+    SimWorkload snapshot();
 }

--- a/opendc-simulator/opendc-simulator-compute/src/test/kotlin/org/opendc/simulator/compute/SimMachineTest.kt
+++ b/opendc-simulator/opendc-simulator-compute/src/test/kotlin/org/opendc/simulator/compute/SimMachineTest.kt
@@ -177,6 +177,8 @@ class SimMachineTest {
             }
 
             override fun onStop(ctx: SimMachineContext) {}
+
+            override fun snapshot(): SimWorkload = TODO()
         })
     }
 
@@ -197,6 +199,8 @@ class SimMachineTest {
             }
 
             override fun onStop(ctx: SimMachineContext) {}
+
+            override fun snapshot(): SimWorkload = TODO()
         })
     }
 
@@ -217,6 +221,8 @@ class SimMachineTest {
             }
 
             override fun onStop(ctx: SimMachineContext) {}
+
+            override fun snapshot(): SimWorkload = TODO()
         })
 
         assertEquals(1000, clock.millis())
@@ -243,6 +249,8 @@ class SimMachineTest {
             }
 
             override fun onStop(ctx: SimMachineContext) {}
+
+            override fun snapshot(): SimWorkload = TODO()
         })
 
         assertEquals(40, clock.millis())
@@ -266,6 +274,8 @@ class SimMachineTest {
             }
 
             override fun onStop(ctx: SimMachineContext) {}
+
+            override fun snapshot(): SimWorkload = TODO()
         })
 
         assertEquals(4000, clock.millis())
@@ -289,6 +299,8 @@ class SimMachineTest {
             }
 
             override fun onStop(ctx: SimMachineContext) {}
+
+            override fun snapshot(): SimWorkload = TODO()
         })
 
         assertEquals(4000, clock.millis())

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/flow2/FlowStage.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/flow2/FlowStage.java
@@ -152,6 +152,15 @@ public final class FlowStage {
     }
 
     /**
+     * Synchronously update the {@link FlowStage} at the current timestamp.
+     */
+    public void sync() {
+        this.flags |= STAGE_INVALIDATE;
+        onUpdate(clock.millis());
+        engine.scheduleDelayed(this);
+    }
+
+    /**
      * Close the {@link FlowStage} and disconnect all inlets and outlets.
      */
     public void close() {


### PR DESCRIPTION
## Summary

This pull request adds support for snapshotting simulated workloads in OpenDC, which
serves as the basis for virtual machine migration/suspension support.

Part of #32 

## Implementation Notes :hammer_and_pick:

* Support synchronous update of FlowStage
* Report exceptions in onStop as suppressed 
* Add support for snapshotting workloads

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A