### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,9 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build codeCoverageReport
-          # Only write to the cache for builds on the 'main' branch.
+          # Only write to the cache for builds on the 'master' branch.
           # Builds on other branches will only read existing entries from the cache.
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
       - name: Publish report
         if: always()
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build codeCoverageReport
+          arguments: build assembleDist codeCoverageReport
           # Only write to the cache for builds on the 'master' branch.
           # Builds on other branches will only read existing entries from the cache.
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
@@ -41,7 +41,7 @@ jobs:
           check_name: test (Java ${{ matrix.java }})
           report_paths: '**/build/test-results/test/TEST-*.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload artifacts
+      - name: Upload reports
         if: always()
         continue-on-error: true # See https://github.com/actions/upload-artifact/issues/270
         uses: actions/upload-artifact@v3
@@ -50,6 +50,14 @@ jobs:
           path: |
             ./**/build/reports/**/*
             ./**/build/test-results/**/*
+          retention-days: 5
+      - name: Upload build
+        continue-on-error: true
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-${{ matrix.os }}-jdk${{ matrix.java }}
+          path: |
+            ./**/build/distributions/**/*.zip
           retention-days: 5
       - name: Upload code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-22.04 ]
         java: [ 17, 19 ]
         include:
-          - os: windows-latest
+          - os: windows-2022
             java: 17
     steps:
       - name: Checkout repository
@@ -58,7 +58,7 @@ jobs:
           files: ./build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
   build-docker:
     name: Build Docker Images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -80,7 +80,7 @@ jobs:
       run:
         working-directory: site
     name: Build Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy-app:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Create SSH key
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,7 +14,7 @@ jobs:
     defaults:
       run:
         working-directory: site
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
-name: Publish Docker image
+# Workflow for publishing the artifacts once a GitHub release is published
+name: Publish
 
 on:
   release:
@@ -6,16 +7,16 @@ on:
 
 jobs:
   push-simulator:
-    name: Push Simulator
+    name: Push Simulator to DockerHub
     runs-on: ubuntu-22.04
     steps:
       - name: Prepare
         id: prep
         run: |
           DOCKER_IMAGE=atlargeresearch/opendc
-          VERSION=edge
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=3.0-SNAPSHOT
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
           fi
           echo "tags=${DOCKER_IMAGE}:${VERSION}" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
@@ -31,16 +32,16 @@ jobs:
           repository: atlargeresearch/opendc
           tags: ${{ steps.prep.outputs.tags }}
   push-api:
-    name: Push API
+    name: Push API to DockerHub
     runs-on: ubuntu-22.04
     steps:
       - name: Prepare
         id: prep
         run: |
           DOCKER_IMAGE=atlargeresearch/opendc-web-api
-          VERSION=edge
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=3.0-SNAPSHOT
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
           fi
           echo "tags=${DOCKER_IMAGE}:${VERSION}" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
@@ -55,16 +56,16 @@ jobs:
           file: opendc-web/opendc-web-server/Dockerfile
           tags: ${{ steps.prep.outputs.tags }}
   push-ui:
-    name: Push UI
+    name: Push UI to DockerHub
     runs-on: ubuntu-22.04
     steps:
       - name: Prepare
         id: prep
         run: |
           DOCKER_IMAGE=atlargeresearch/opendc-web-ui
-          VERSION=edge
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=3.0-SNAPSHOT
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
           fi
           echo "tags=${DOCKER_IMAGE}:${VERSION}" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
@@ -78,3 +79,33 @@ jobs:
           push: true
           context: opendc-web/opendc-web-ui
           tags: ${{ steps.prep.outputs.tags }}
+  publish-maven-central:
+    name: Publish to Maven Central
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+      - name: Prepare
+        id: prep
+        run: |
+          VERSION=3.0-SNAPSHOT
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Publish with Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publish -Pversion="${{ steps.prep.outputs.version }}"
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   push-simulator:
     name: Push Simulator
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Prepare
         id: prep
@@ -32,7 +32,7 @@ jobs:
           tags: ${{ steps.prep.outputs.tags }}
   push-api:
     name: Push API
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Prepare
         id: prep
@@ -56,7 +56,7 @@ jobs:
           tags: ${{ steps.prep.outputs.tags }}
   push-ui:
     name: Push UI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Prepare
         id: prep

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,7 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${DOCKER_IMAGE}:${VERSION}" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -43,8 +42,7 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${DOCKER_IMAGE}:${VERSION}" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -54,8 +52,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           push: true
-          file: opendc-web/opendc-web-api/Dockerfile
-          repository: atlargeresearch/opendc-web-api
+          file: opendc-web/opendc-web-server/Dockerfile
           tags: ${{ steps.prep.outputs.tags }}
   push-ui:
     name: Push UI
@@ -69,8 +66,7 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          echo ::set-output name=tags::${TAGS}
+          echo "tags=${DOCKER_IMAGE}:${VERSION}" >> $GITHUB_OUTPUT
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -81,5 +77,4 @@ jobs:
         with:
           push: true
           context: opendc-web/opendc-web-ui
-          repository: atlargeresearch/opendc-web-ui
           tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+# Workflow for creating a draft release once a new tag is pushed to GitHub
 name: Release
 
 on:
@@ -21,12 +22,7 @@ jobs:
       - name: Publish with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: publish
-        env:
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+          arguments: assembleDist
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build OpenDC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/test-gradle-rc.yml
+++ b/.github/workflows/test-gradle-rc.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   gradle-rc:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/test-java-ea.yml
+++ b/.github/workflows/test-java-ea.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   java-ea:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,3 @@ plugins {
     `dokka-conventions`
     `jacoco-aggregation`
 }
-
-allprojects {
-    version = "3.0-rc1"
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,9 @@
 # SOFTWARE.
 #
 
+group           = org.opendc
+version         = 3.0-SNAPSHOT
+
 # For Dokka https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2G
 


### PR DESCRIPTION
## Summary

This pull request updates the GitHub Actions workflows used in the OpenDC repository, addressing (impending) deprecations, broken caching and publishing steps.

## Implementation Notes :hammer_and_pick:

* Fix GH Actions workflow for publishing Docker images
* Enable Gradle caching on master branch
* Pin version of GitHub Actions runner images 
* Publish to Maven Central in publish workflow 
* Upload distributions after CI build
