### PR TITLE
Heap size comparison was incorrect. Fixed

### DIFF
--- a/opendc-simulator/opendc-simulator-core/src/main/java/org/opendc/simulator/TaskQueue.java
+++ b/opendc-simulator/opendc-simulator-core/src/main/java/org/opendc/simulator/TaskQueue.java
@@ -183,7 +183,7 @@ final class TaskQueue {
         int oldCapacity = deadlines.length;
 
         // Double size if small; else grow by 50%
-        int newCapacity = oldCapacity + oldCapacity < 64 ? oldCapacity + 2 : oldCapacity >> 1;
+        int newCapacity = oldCapacity + (oldCapacity < 64 ? oldCapacity + 2 : oldCapacity >> 1);
 
         deadlines = Arrays.copyOf(deadlines, newCapacity);
         ids = Arrays.copyOf(ids, newCapacity);


### PR DESCRIPTION
## Summary

When the event heap size in task queue needs to grow, the new heap size is computed incorrectly.
The addition happens before the comparison, whereas it should happen afterwards.

## Implementation Notes :hammer_and_pick:

Adds brackets so that the comparison happens before addition.

## External Dependencies :four_leaf_clover:
N/A

## Breaking API Changes :warning:
N/A

*Simply specify none (N/A) if not applicable.*