### PR TITLE
Migrate to GitHub Container Registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   push:
     branches: [ master ]
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=atlargeresearch/opendc
+          DOCKER_IMAGE=ghcr.io/atlarge-research/opendc
           VERSION=3.0-SNAPSHOT
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
@@ -22,8 +22,9 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to Docker Hub
         uses: docker/build-push-action@v4
         with:
@@ -37,7 +38,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=atlargeresearch/opendc-web-api
+          DOCKER_IMAGE=ghcr.io/atlarge-research/opendc-web-api
           VERSION=3.0-SNAPSHOT
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
@@ -46,8 +47,9 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to Docker Hub
         uses: docker/build-push-action@v4
         with:
@@ -63,7 +65,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=atlargeresearch/opendc-web-ui
+          DOCKER_IMAGE=ghcr.io/atlarge-research/opendc-web-ui
           VERSION=3.0-SNAPSHOT
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
@@ -72,8 +74,9 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push to Docker Hub
         uses: docker/build-push-action@v4
         with:

--- a/opendc-web/opendc-web-runner/Dockerfile
+++ b/opendc-web/opendc-web-runner/Dockerfile
@@ -16,3 +16,11 @@ COPY --from=0 /app/opendc-web/opendc-web-runner/build/install /opt/
 COPY --from=0 /app/traces /opt/opendc/traces
 WORKDIR /opt/opendc
 CMD bin/opendc-web-runner
+
+LABEL org.opencontainers.image.authors="OpenDC Maintainers <opendc@atlarge-research.com>"
+LABEL org.opencontainers.image.url="https://opendc.org"
+LABEL org.opencontainers.image.documentation="https://opendc.org"
+LABEL org.opencontainers.image.source="https://github.com/atlarge-research/opendc"
+LABEL org.opencontainers.image.title="OpenDC Web Runner UI"
+LABEL org.opencontainers.image.description="OpenDC Web Runner Docker Image"
+LABEL org.opencontainers.image.vendor="AtLarge Research"

--- a/opendc-web/opendc-web-server/Dockerfile
+++ b/opendc-web/opendc-web-server/Dockerfile
@@ -23,3 +23,11 @@ FROM openjdk:17-slim
 COPY --from=0 /app/opendc-web/opendc-web-server/build/quarkus-app /opt/opendc
 WORKDIR /opt/opendc
 CMD java -jar quarkus-run.jar
+
+LABEL org.opencontainers.image.authors="OpenDC Maintainers <opendc@atlarge-research.com>"
+LABEL org.opencontainers.image.url="https://opendc.org"
+LABEL org.opencontainers.image.documentation="https://opendc.org"
+LABEL org.opencontainers.image.source="https://github.com/atlarge-research/opendc"
+LABEL org.opencontainers.image.title="OpenDC"
+LABEL org.opencontainers.image.description="OpenDC Docker Image"
+LABEL org.opencontainers.image.vendor="AtLarge Research"

--- a/opendc-web/opendc-web-ui/Dockerfile
+++ b/opendc-web/opendc-web-ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 AS staging
+FROM node:18-slim AS staging
 MAINTAINER OpenDC Maintainers <opendc@atlarge-research.com>
 
 # Copy package details
@@ -6,7 +6,7 @@ COPY ./package.json ./package-lock.json /opendc/
 RUN cd /opendc && npm ci
 
 # Build frontend
-FROM node:18 AS build
+FROM node:18-slim AS build
 
 COPY ./ /opendc
 COPY --from=staging /opendc/node_modules /opendc/node_modules
@@ -26,3 +26,11 @@ FROM node:18-slim
 COPY --from=build /opendc /opendc
 WORKDIR /opendc
 CMD ./scripts/envsubst.sh; npm run start
+
+LABEL org.opencontainers.image.authors="OpenDC Maintainers <opendc@atlarge-research.com>"
+LABEL org.opencontainers.image.url="https://opendc.org"
+LABEL org.opencontainers.image.documentation="https://opendc.org"
+LABEL org.opencontainers.image.source="https://github.com/atlarge-research/opendc"
+LABEL org.opencontainers.image.title="OpenDC Web UI"
+LABEL org.opencontainers.image.description="OpenDC Web UI Docker Image"
+LABEL org.opencontainers.image.vendor="AtLarge Research"


### PR DESCRIPTION
Docker Inc is sunsetting free team organizations for the Docker registry, which our organization is one of. Instead, a paid subscription is now required to maintain the organization.

Given our relatively small usage of the account, it makes more sense to start publishing the container images on the GitHub Container Registry, since it is free for open source projects and integrates well with GitHub Actions.

Fixes #141