### PR TITLE
Updated metrics and parquet output

### DIFF
--- a/opendc-compute/opendc-compute-service/src/main/java/org/opendc/compute/service/driver/telemetry/HostSystemStats.java
+++ b/opendc-compute/opendc-compute-service/src/main/java/org/opendc/compute/service/driver/telemetry/HostSystemStats.java
@@ -31,7 +31,7 @@ import java.time.Instant;
  * @param uptime The cumulative uptime of the host since last boot (in ms).
  * @param downtime The cumulative downtime of the host since last boot (in ms).
  * @param bootTime The time at which the server started.
- * @param powerUsage Instantaneous power usage of the system (in W).
+ * @param powerDraw Instantaneous power draw of the system (in W).
  * @param energyUsage The cumulative energy usage of the system (in J).
  * @param guestsTerminated The number of guests that are in a terminated state.
  * @param guestsRunning The number of guests that are in a running state.
@@ -42,7 +42,7 @@ public record HostSystemStats(
         Duration uptime,
         Duration downtime,
         Instant bootTime,
-        double powerUsage,
+        double powerDraw,
         double energyUsage,
         int guestsTerminated,
         int guestsRunning,

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
@@ -229,7 +229,7 @@ public class SimHost(
             Duration.ofMillis(_uptime),
             Duration.ofMillis(_downtime),
             _bootTime,
-            machine.psu.powerUsage,
+            machine.psu.powerDraw,
             machine.psu.energyUsage,
             terminated,
             running,

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/ComputeMetricReader.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/ComputeMetricReader.kt
@@ -227,8 +227,8 @@ public class ComputeMetricReader(
             _cpuIdleTime = table.cpuIdleTime
             _cpuStealTime = table.cpuStealTime
             _cpuLostTime = table.cpuLostTime
-            _powerUsage = table.powerUsage
-            _powerTotal = table.powerTotal
+            _powerDraw = table.powerDraw
+            _energyUsage = table.energyUsage
             _uptime = table.uptime
             _downtime = table.downtime
             _bootTime = table.bootTime
@@ -294,13 +294,13 @@ public class ComputeMetricReader(
         private var _cpuLostTime = 0L
         private var previousCpuLostTime = 0L
 
-        override val powerUsage: Double
-            get() = _powerUsage
-        private var _powerUsage = 0.0
+        override val powerDraw: Double
+            get() = _powerDraw
+        private var _powerDraw = 0.0
 
-        override val powerTotal: Double
-            get() = _powerTotal - previousPowerTotal
-        private var _powerTotal = 0.0
+        override val energyUsage: Double
+            get() = _energyUsage - previousPowerTotal
+        private var _energyUsage = 0.0
         private var previousPowerTotal = 0.0
 
         override val uptime: Long
@@ -337,8 +337,8 @@ public class ComputeMetricReader(
             _cpuIdleTime = hostCpuStats.idleTime
             _cpuStealTime = hostCpuStats.stealTime
             _cpuLostTime = hostCpuStats.lostTime
-            _powerUsage = hostSysStats.powerUsage
-            _powerTotal = hostSysStats.energyUsage
+            _powerDraw = hostSysStats.powerDraw
+            _energyUsage = hostSysStats.energyUsage
             _uptime = hostSysStats.uptime.toMillis()
             _downtime = hostSysStats.downtime.toMillis()
             _bootTime = hostSysStats.bootTime
@@ -353,7 +353,7 @@ public class ComputeMetricReader(
             previousCpuIdleTime = _cpuIdleTime
             previousCpuStealTime = _cpuStealTime
             previousCpuLostTime = _cpuLostTime
-            previousPowerTotal = _powerTotal
+            previousPowerTotal = _energyUsage
             previousUptime = _uptime
             previousDowntime = _downtime
 
@@ -367,7 +367,7 @@ public class ComputeMetricReader(
             _cpuDemand = 0.0
             _cpuUtilization = 0.0
 
-            _powerUsage = 0.0
+            _powerDraw = 0.0
         }
     }
 

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetComputeMonitor.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetComputeMonitor.kt
@@ -33,17 +33,17 @@ import java.io.File
  */
 public class ParquetComputeMonitor(base: File, partition: String, bufferSize: Int) : ComputeMonitor, AutoCloseable {
     private val serverWriter = ParquetServerDataWriter(
-        File(base, "server/$partition/data.parquet").also { it.parentFile.mkdirs() },
+        File(base, "$partition/server.parquet").also { it.parentFile.mkdirs() },
         bufferSize
     )
 
     private val hostWriter = ParquetHostDataWriter(
-        File(base, "host/$partition/data.parquet").also { it.parentFile.mkdirs() },
+        File(base, "$partition/host.parquet").also { it.parentFile.mkdirs() },
         bufferSize
     )
 
     private val serviceWriter = ParquetServiceDataWriter(
-        File(base, "service/$partition/data.parquet").also { it.parentFile.mkdirs() },
+        File(base, "$partition/service.parquet").also { it.parentFile.mkdirs() },
         bufferSize
     )
 

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetHostDataWriter.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetHostDataWriter.kt
@@ -134,23 +134,27 @@ public class ParquetHostDataWriter(path: File, bufferSize: Int) :
             consumer.addLong(data.cpuLostTime)
             consumer.endField("cpu_time_lost", 15)
 
-            consumer.startField("power_total", 16)
-            consumer.addDouble(data.powerTotal)
-            consumer.endField("power_total", 16)
+            consumer.startField("power_draw", 16)
+            consumer.addDouble(data.powerDraw)
+            consumer.endField("power_draw", 16)
 
-            consumer.startField("uptime", 17)
+            consumer.startField("energy_usage", 17)
+            consumer.addDouble(data.energyUsage)
+            consumer.endField("energy_usage", 17)
+
+            consumer.startField("uptime", 18)
             consumer.addLong(data.uptime)
-            consumer.endField("uptime", 17)
+            consumer.endField("uptime", 18)
 
-            consumer.startField("downtime", 18)
+            consumer.startField("downtime", 19)
             consumer.addLong(data.downtime)
-            consumer.endField("downtime", 18)
+            consumer.endField("downtime", 19)
 
             val bootTime = data.bootTime
             if (bootTime != null) {
-                consumer.startField("boot_time", 19)
+                consumer.startField("boot_time", 20)
                 consumer.addLong(bootTime.toEpochMilli())
-                consumer.endField("boot_time", 19)
+                consumer.endField("boot_time", 20)
             }
 
             consumer.endMessage()
@@ -216,7 +220,10 @@ public class ParquetHostDataWriter(path: File, bufferSize: Int) :
                     .named("cpu_time_lost"),
                 Types
                     .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
-                    .named("power_total"),
+                    .named("power_draw"),
+                Types
+                    .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+                    .named("energy_usage"),
                 Types
                     .required(PrimitiveType.PrimitiveTypeName.INT64)
                     .named("uptime"),

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/table/HostTableReader.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/table/HostTableReader.kt
@@ -104,14 +104,14 @@ public interface HostTableReader {
     public val cpuLostTime: Long
 
     /**
-     * The current power usage of the host in W.
+     * The current power draw of the host in W.
      */
-    public val powerUsage: Double
+    public val powerDraw: Double
 
     /**
-     * The total power consumption of the host since last time in J.
+     * The total energy consumption of the host since last time in J.
      */
-    public val powerTotal: Double
+    public val energyUsage: Double
 
     /**
      * The uptime of the host since last time in ms.

--- a/opendc-experiments/opendc-experiments-capelin/src/test/kotlin/org/opendc/experiments/capelin/CapelinIntegrationTest.kt
+++ b/opendc-experiments/opendc-experiments-capelin/src/test/kotlin/org/opendc/experiments/capelin/CapelinIntegrationTest.kt
@@ -280,7 +280,7 @@ class CapelinIntegrationTest {
             activeTime += reader.cpuActiveTime
             stealTime += reader.cpuStealTime
             lostTime += reader.cpuLostTime
-            energyUsage += reader.powerTotal
+            energyUsage += reader.energyUsage
             uptime += reader.uptime
         }
     }

--- a/opendc-experiments/opendc-experiments-greenifier/src/main/Python_scripts/OpenDCdemo.ipynb
+++ b/opendc-experiments/opendc-experiments-greenifier/src/main/Python_scripts/OpenDCdemo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "18170001",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
     "\n",
     "from IPython.display import display, HTML\n",
     "\n",
-    "base_folder = \"../../../../..\""
+    "base_folder = \"../\""
    ]
   },
   {
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "a2d05361",
    "metadata": {},
    "outputs": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 140,
+   "execution_count": 5,
    "id": "fd17d88a",
    "metadata": {},
    "outputs": [
@@ -251,7 +251,7 @@
        "4  1019 2013-08-12 14:15:46+00:00    900000          1   0.000000"
       ]
      },
-     "execution_count": 140,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 141,
+   "execution_count": 6,
    "id": "346f097f",
    "metadata": {
     "scrolled": true
@@ -364,7 +364,7 @@
        "4   2599.999649        179306  "
       ]
      },
-     "execution_count": 141,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -392,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 144,
+   "execution_count": 10,
    "id": "0d400ffd",
    "metadata": {},
    "outputs": [],
@@ -401,14 +401,14 @@
     "workload = \"workload=bitbrains-small\"\n",
     "seed = \"seed=0\"\n",
     "\n",
-    "df_host_single = pd.read_parquet(f\"{output_folder}/host/topology=single/{workload}/{seed}/data.parquet\")\n",
-    "df_host_multi = pd.read_parquet(f\"{output_folder}/host/topology=multi/{workload}/{seed}/data.parquet\")\n",
+    "df_host_single = pd.read_parquet(f\"{output_folder}/topology=single/{workload}/{seed}/host.parquet\")\n",
+    "df_host_multi = pd.read_parquet(f\"{output_folder}/topology=multi/{workload}/{seed}/host.parquet\")\n",
     "\n",
-    "df_server_single = pd.read_parquet(f\"{output_folder}/server/topology=single/{workload}/{seed}/data.parquet\")\n",
-    "df_server_multi = pd.read_parquet(f\"{output_folder}/server/topology=multi/{workload}/{seed}/data.parquet\")\n",
+    "df_server_single = pd.read_parquet(f\"{output_folder}/topology=single/{workload}/{seed}/server.parquet\")\n",
+    "df_server_multi = pd.read_parquet(f\"{output_folder}/topology=multi/{workload}/{seed}/server.parquet\")\n",
     "\n",
-    "df_service_single = pd.read_parquet(f\"{output_folder}/service/topology=single/{workload}/{seed}/data.parquet\")\n",
-    "df_service_multi = pd.read_parquet(f\"{output_folder}/service/topology=multi/{workload}/{seed}/data.parquet\")\n",
+    "df_service_single = pd.read_parquet(f\"{output_folder}/topology=single/{workload}/{seed}/service.parquet\")\n",
+    "df_service_multi = pd.read_parquet(f\"{output_folder}/topology=multi/{workload}/{seed}/service.parquet\")\n",
     "\n",
     "def add_absolute_timestamp(df, start_dt):\n",
     "    df[\"absolute_timestamp\"] = start_dt + (df[\"timestamp\"] - df[\"timestamp\"].min())\n",
@@ -425,76 +425,125 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 145,
+   "execution_count": 11,
    "id": "a9a61332",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "25922"
+       "Index(['timestamp', 'host_id', 'cpu_count', 'mem_capacity',\n",
+       "       'guests_terminated', 'guests_running', 'guests_error', 'guests_invalid',\n",
+       "       'cpu_limit', 'cpu_usage', 'cpu_demand', 'cpu_utilization',\n",
+       "       'cpu_time_active', 'cpu_time_idle', 'cpu_time_steal', 'cpu_time_lost',\n",
+       "       'power_draw', 'energy_usage', 'uptime', 'downtime', 'boot_time',\n",
+       "       'absolute_timestamp'],\n",
+       "      dtype='object')"
       ]
      },
-     "execution_count": 145,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "len(df_service_single)"
+    "df_host_single.columns"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 146,
+   "execution_count": 12,
    "id": "d6fb41d9",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1970-01-01 00:05:00+00:00    1\n",
-       "1970-03-01 23:55:00+00:00    1\n",
-       "1970-03-02 00:45:00+00:00    1\n",
-       "1970-03-02 00:40:00+00:00    1\n",
-       "1970-03-02 00:35:00+00:00    1\n",
-       "                            ..\n",
-       "1970-01-30 23:50:00+00:00    1\n",
-       "1970-01-30 23:45:00+00:00    1\n",
-       "1970-01-30 23:40:00+00:00    1\n",
-       "1970-01-30 23:35:00+00:00    1\n",
-       "1970-04-01 00:10:00+00:00    1\n",
-       "Name: timestamp, Length: 25922, dtype: int64"
+       "0        350.000000\n",
+       "1        350.000000\n",
+       "2        350.000000\n",
+       "3        291.779985\n",
+       "4        297.482719\n",
+       "            ...    \n",
+       "25918    267.445769\n",
+       "25919    276.532201\n",
+       "25920    263.564494\n",
+       "25921    273.482545\n",
+       "25922    200.000186\n",
+       "Name: power_draw, Length: 25923, dtype: float64"
       ]
      },
-     "execution_count": 146,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df_host_single.timestamp.value_counts()"
+    "df_host_single.power_draw"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 149,
+   "execution_count": 13,
+   "id": "3c271734",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0        105000.000000\n",
+       "1        105000.000000\n",
+       "2        105000.000000\n",
+       "3         87533.995628\n",
+       "4         89244.815826\n",
+       "             ...      \n",
+       "25918     79980.733894\n",
+       "25919     80669.879478\n",
+       "25920     82337.210297\n",
+       "25921     79545.414650\n",
+       "25922     68917.601292\n",
+       "Name: energy_usage, Length: 25923, dtype: float64"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_host_single.energy_usage"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "id": "89977c44",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([50, 49, 48, 47, 46, 45, 44, 35, 34, 16, 15, 14, 13, 12, 11, 10])"
+       "0       1970-01-01 00:05:00+00:00\n",
+       "1       1970-01-01 00:10:00+00:00\n",
+       "2       1970-01-01 00:15:00+00:00\n",
+       "3       1970-01-01 00:20:00+00:00\n",
+       "4       1970-01-01 00:25:00+00:00\n",
+       "                   ...           \n",
+       "25918   1970-03-31 23:55:00+00:00\n",
+       "25919   1970-04-01 00:00:00+00:00\n",
+       "25920   1970-04-01 00:05:00+00:00\n",
+       "25921   1970-04-01 00:10:00+00:00\n",
+       "25922   1970-04-01 00:14:12+00:00\n",
+       "Name: timestamp, Length: 25923, dtype: datetime64[ns, UTC]"
       ]
      },
-     "execution_count": 149,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df_server_single.timestamp.value_counts().unique()"
+    "df_host_single.timestamp"
    ]
   },
   {

--- a/opendc-experiments/opendc-experiments-greenifier/src/test/kotlin/org/opendc/experiments/greenifier/GreenifierIntegrationTest.kt
+++ b/opendc-experiments/opendc-experiments-greenifier/src/test/kotlin/org/opendc/experiments/greenifier/GreenifierIntegrationTest.kt
@@ -280,7 +280,7 @@ class GreenifierIntegrationTest {
             activeTime += reader.cpuActiveTime
             stealTime += reader.cpuStealTime
             lostTime += reader.cpuLostTime
-            energyUsage += reader.powerTotal
+            energyUsage += reader.energyUsage
             uptime += reader.uptime
         }
     }

--- a/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/SimTFDevice.kt
+++ b/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/SimTFDevice.kt
@@ -168,7 +168,7 @@ public class SimTFDevice(
     }
 
     override fun getDeviceStats(): TFDeviceStats {
-        return TFDeviceStats(machine.cpuUsage, machine.psu.powerUsage, machine.psu.energyUsage)
+        return TFDeviceStats(machine.cpuUsage, machine.psu.powerDraw, machine.psu.energyUsage)
     }
 
     override fun close() {

--- a/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/TFDeviceStats.kt
+++ b/opendc-experiments/opendc-experiments-tf20/src/main/kotlin/org/opendc/experiments/tf20/core/TFDeviceStats.kt
@@ -26,11 +26,11 @@ package org.opendc.experiments.tf20.core
  * Statistics about a TensorFlow [TFDevice].
  *
  * @property resourceUsage The resource usage of the device (in MHz).
- * @property powerUsage The instantaneous power draw of the device (in W).
+ * @property powerDraw The instantaneous power draw of the device (in W).
  * @property energyUsage Cumulative energy usage of the device since boot (in J).
  */
 data class TFDeviceStats(
     val resourceUsage: Double,
-    val powerUsage: Double,
+    val powerDraw: Double,
     val energyUsage: Double
 )

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsu.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsu.java
@@ -43,7 +43,7 @@ public abstract class SimPsu extends SimPowerInlet {
     /**
      * Return the instantaneous power usage of the machine (in W) measured at the inlet of the power supply.
      */
-    public abstract double getPowerUsage();
+    public abstract double getPowerDraw();
 
     /**
      * Return the cumulated energy usage of the machine (in J) measured at the inlet of the powers supply.

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsuFactories.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsuFactories.java
@@ -82,7 +82,7 @@ public class SimPsuFactories {
         }
 
         @Override
-        public double getPowerUsage() {
+        public double getPowerDraw() {
             return 0;
         }
 
@@ -123,7 +123,7 @@ public class SimPsuFactories {
         private double totalUsage;
         private long lastUpdate;
 
-        private double powerUsage;
+        private double powerDraw;
         private double energyUsage;
 
         private final InHandler handler = new InHandler() {
@@ -154,8 +154,8 @@ public class SimPsuFactories {
         }
 
         @Override
-        public double getPowerUsage() {
-            return powerUsage;
+        public double getPowerDraw() {
+            return powerDraw;
         }
 
         @Override
@@ -186,7 +186,7 @@ public class SimPsuFactories {
 
             double usage = model.computePower(totalUsage / targetFreq);
             out.push((float) usage);
-            powerUsage = usage;
+            powerDraw = usage;
 
             return Long.MAX_VALUE;
         }
@@ -207,7 +207,7 @@ public class SimPsuFactories {
             long duration = now - lastUpdate;
             if (duration > 0) {
                 // Compute the energy usage of the machine
-                energyUsage += powerUsage * duration * 0.001;
+                energyUsage += powerDraw * duration * 0.001;
             }
         }
     }

--- a/opendc-simulator/opendc-simulator-compute/src/test/kotlin/org/opendc/simulator/compute/SimMachineTest.kt
+++ b/opendc-simulator/opendc-simulator-compute/src/test/kotlin/org/opendc/simulator/compute/SimMachineTest.kt
@@ -148,7 +148,7 @@ class SimMachineTest {
 
             yield()
             assertAll(
-                { assertEquals(100.0, machine.psu.powerUsage) },
+                { assertEquals(100.0, machine.psu.powerDraw) },
                 { assertEquals(100.0f, source.powerDraw) }
             )
         }

--- a/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/internal/WebComputeMonitor.kt
+++ b/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/internal/WebComputeMonitor.kt
@@ -41,7 +41,7 @@ internal class WebComputeMonitor : ComputeMonitor {
             hostAggregateMetrics.totalIdleTime + reader.cpuIdleTime,
             hostAggregateMetrics.totalStealTime + reader.cpuStealTime,
             hostAggregateMetrics.totalLostTime + reader.cpuLostTime,
-            hostAggregateMetrics.totalPowerDraw + reader.powerTotal,
+            hostAggregateMetrics.totalPowerDraw + reader.energyUsage,
             hostAggregateMetrics.totalFailureSlices + slices,
             hostAggregateMetrics.totalFailureVmSlices + reader.guestsRunning * slices
         )


### PR DESCRIPTION
## Summary

Added power_draw to the output metrics. Renamed power_total to energy_usage

## Implementation Notes :hammer_and_pick:

The metric power_total is renamed to energy_usage to better explain what it does. 
power_draw is added as an additional metric. 

power_draw states the power drawn by the component when monitored in Watt.
energy_usage takes the sample rate into account, en states the energy used since the previous sample in Joule.

The folder structure of the parquet files is changed. All three parquet files are now put in the same folder, with a different name.

## External Dependencies :four_leaf_clover:

N/A

## Breaking API Changes :warning:

1. power_total is renamed to energy_usage
2. The folder structure of the parquet files is changed.

*Simply specify none (N/A) if not applicable.*