### PR TITLE
Metric update

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
@@ -248,10 +248,10 @@ public class SimHost(
         counters.sync()
 
         return HostCpuStats(
-            counters.cpuActiveTime / 1000L,
-            counters.cpuIdleTime / 1000L,
-            counters.cpuStealTime / 1000L,
-            counters.cpuLostTime / 1000L,
+            counters.cpuActiveTime,
+            counters.cpuIdleTime,
+            counters.cpuStealTime,
+            counters.cpuLostTime,
             hypervisor.cpuCapacity,
             hypervisor.cpuDemand,
             hypervisor.cpuUsage,

--- a/opendc-compute/opendc-compute-simulator/src/test/kotlin/org/opendc/compute/simulator/SimHostTest.kt
+++ b/opendc-compute/opendc-compute-simulator/src/test/kotlin/org/opendc/compute/simulator/SimHostTest.kt
@@ -128,9 +128,9 @@ internal class SimHostTest {
         val cpuStats = host.getCpuStats()
 
         assertAll(
-            { assertEquals(639, cpuStats.activeTime, "Active time does not match") },
-            { assertEquals(2360, cpuStats.idleTime, "Idle time does not match") },
-            { assertEquals(56, cpuStats.stealTime, "Steal time does not match") },
+            { assertEquals(639564, cpuStats.activeTime, "Active time does not match") },
+            { assertEquals(2360433, cpuStats.idleTime, "Idle time does not match") },
+            { assertEquals(56251, cpuStats.stealTime, "Steal time does not match") },
             { assertEquals(1499999, timeSource.millis()) }
         )
     }
@@ -215,9 +215,9 @@ internal class SimHostTest {
         val cpuStats = host.getCpuStats()
 
         assertAll(
-            { assertEquals(658, cpuStats.activeTime, "Active time does not match") },
-            { assertEquals(2341, cpuStats.idleTime, "Idle time does not match") },
-            { assertEquals(637, cpuStats.stealTime, "Steal time does not match") },
+            { assertEquals(658502, cpuStats.activeTime, "Active time does not match") },
+            { assertEquals(2341496, cpuStats.idleTime, "Idle time does not match") },
+            { assertEquals(637504, cpuStats.stealTime, "Steal time does not match") },
             { assertEquals(1499999, timeSource.millis()) }
         )
     }
@@ -287,8 +287,8 @@ internal class SimHostTest {
         val guestSysStats = host.getSystemStats(server)
 
         assertAll(
-            { assertEquals(1770, cpuStats.idleTime, "Idle time does not match") },
-            { assertEquals(639, cpuStats.activeTime, "Active time does not match") },
+            { assertEquals(1770344, cpuStats.idleTime, "Idle time does not match") },
+            { assertEquals(639653, cpuStats.activeTime, "Active time does not match") },
             { assertEquals(1204999, sysStats.uptime.toMillis(), "Uptime does not match") },
             { assertEquals(300000, sysStats.downtime.toMillis(), "Downtime does not match") },
             { assertEquals(1204999, guestSysStats.uptime.toMillis(), "Guest uptime does not match") },

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetHostDataWriter.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetHostDataWriter.kt
@@ -170,7 +170,7 @@ public class ParquetHostDataWriter(path: File, bufferSize: Int) :
             .addFields(
                 Types
                     .required(PrimitiveType.PrimitiveTypeName.INT64)
-                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+//                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
                     .named("timestamp"),
                 Types
                     .required(PrimitiveType.PrimitiveTypeName.BINARY)
@@ -232,7 +232,7 @@ public class ParquetHostDataWriter(path: File, bufferSize: Int) :
                     .named("downtime"),
                 Types
                     .optional(PrimitiveType.PrimitiveTypeName.INT64)
-                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+//                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
                     .named("boot_time")
             )
             .named("host")

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetServerDataWriter.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetServerDataWriter.kt
@@ -152,7 +152,7 @@ public class ParquetServerDataWriter(path: File, bufferSize: Int) :
             .addFields(
                 Types
                     .required(PrimitiveType.PrimitiveTypeName.INT64)
-                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+//                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
                     .named("timestamp"),
                 Types
                     .required(PrimitiveType.PrimitiveTypeName.BINARY)
@@ -195,11 +195,11 @@ public class ParquetServerDataWriter(path: File, bufferSize: Int) :
                     .named("downtime"),
                 Types
                     .optional(PrimitiveType.PrimitiveTypeName.INT64)
-                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+//                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
                     .named("provision_time"),
                 Types
                     .optional(PrimitiveType.PrimitiveTypeName.INT64)
-                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+//                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
                     .named("boot_time")
 
             )

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetServiceDataWriter.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetServiceDataWriter.kt
@@ -25,7 +25,6 @@ package org.opendc.compute.telemetry.export.parquet
 import org.apache.hadoop.conf.Configuration
 import org.apache.parquet.hadoop.api.WriteSupport
 import org.apache.parquet.io.api.RecordConsumer
-import org.apache.parquet.schema.LogicalTypeAnnotation
 import org.apache.parquet.schema.MessageType
 import org.apache.parquet.schema.PrimitiveType
 import org.apache.parquet.schema.Types

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetServiceDataWriter.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetServiceDataWriter.kt
@@ -102,7 +102,7 @@ public class ParquetServiceDataWriter(path: File, bufferSize: Int) :
             .addFields(
                 Types
                     .required(PrimitiveType.PrimitiveTypeName.INT64)
-                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
+//                    .`as`(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MILLIS))
                     .named("timestamp"),
                 Types
                     .required(PrimitiveType.PrimitiveTypeName.INT32)

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/table/HostTableReader.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/table/HostTableReader.kt
@@ -84,22 +84,22 @@ public interface HostTableReader {
     public val cpuUtilization: Double
 
     /**
-     * The duration (in seconds) that a CPU was active in the host.
+     * The duration (in ms) that a CPU was active in the host.
      */
     public val cpuActiveTime: Long
 
     /**
-     * The duration (in seconds) that a CPU was idle in the host.
+     * The duration (in ms) that a CPU was idle in the host.
      */
     public val cpuIdleTime: Long
 
     /**
-     * The duration (in seconds) that a vCPU wanted to run, but no capacity was available.
+     * The duration (in ms) that a vCPU wanted to run, but no capacity was available.
      */
     public val cpuStealTime: Long
 
     /**
-     * The duration (in seconds) of CPU time that was lost due to interference.
+     * The duration (in ms) of CPU time that was lost due to interference.
      */
     public val cpuLostTime: Long
 

--- a/opendc-experiments/opendc-experiments-capelin/src/test/kotlin/org/opendc/experiments/capelin/CapelinIntegrationTest.kt
+++ b/opendc-experiments/opendc-experiments-capelin/src/test/kotlin/org/opendc/experiments/capelin/CapelinIntegrationTest.kt
@@ -120,9 +120,9 @@ class CapelinIntegrationTest {
             { assertEquals(0, monitor.serversActive, "All VMs should finish after a run") },
             { assertEquals(0, monitor.attemptsFailure, "No VM should be unscheduled") },
             { assertEquals(0, monitor.serversPending, "No VM should not be in the queue") },
-            { assertEquals(223379987, monitor.idleTime) { "Incorrect idle time" } },
-            { assertEquals(66977088, monitor.activeTime) { "Incorrect active time" } },
-            { assertEquals(3160266, monitor.stealTime) { "Incorrect steal time" } },
+            { assertEquals(223379991650, monitor.idleTime) { "Incorrect idle time" } },
+            { assertEquals(66977091124, monitor.activeTime) { "Incorrect active time" } },
+            { assertEquals(3160267873, monitor.stealTime) { "Incorrect steal time" } },
             { assertEquals(0, monitor.lostTime) { "Incorrect lost time" } },
             { assertEquals(5.8407E9, monitor.energyUsage, 1E4) { "Incorrect power draw" } }
         )
@@ -160,9 +160,9 @@ class CapelinIntegrationTest {
 
         // Note that these values have been verified beforehand
         assertAll(
-            { assertEquals(10996730, monitor.idleTime) { "Idle time incorrect" } },
-            { assertEquals(9741285, monitor.activeTime) { "Active time incorrect" } },
-            { assertEquals(0, monitor.stealTime) { "Steal time incorrect" } },
+            { assertEquals(10996730092, monitor.idleTime) { "Idle time incorrect" } },
+            { assertEquals(9741285381, monitor.activeTime) { "Active time incorrect" } },
+            { assertEquals(152, monitor.stealTime) { "Steal time incorrect" } },
             { assertEquals(0, monitor.lostTime) { "Lost time incorrect" } },
             { assertEquals(7.0109E8, monitor.energyUsage, 1E4) { "Incorrect power draw" } }
         )
@@ -199,10 +199,10 @@ class CapelinIntegrationTest {
 
         // Note that these values have been verified beforehand
         assertAll(
-            { assertEquals(42814948, monitor.idleTime) { "Idle time incorrect" } },
-            { assertEquals(40138266, monitor.activeTime) { "Active time incorrect" } },
-            { assertEquals(23489356, monitor.stealTime) { "Steal time incorrect" } },
-            { assertEquals(424267, monitor.lostTime) { "Lost time incorrect" } }
+            { assertEquals(42814948316, monitor.idleTime) { "Idle time incorrect" } },
+            { assertEquals(40138266225, monitor.activeTime) { "Active time incorrect" } },
+            { assertEquals(23489356981, monitor.stealTime) { "Steal time incorrect" } },
+            { assertEquals(424267131, monitor.lostTime) { "Lost time incorrect" } }
         )
     }
 
@@ -229,9 +229,9 @@ class CapelinIntegrationTest {
 
         // Note that these values have been verified beforehand
         assertAll(
-            { assertEquals(1404277, monitor.idleTime) { "Idle time incorrect" } },
-            { assertEquals(1478675, monitor.activeTime) { "Active time incorrect" } },
-            { assertEquals(0, monitor.stealTime) { "Steal time incorrect" } },
+            { assertEquals(1404277711, monitor.idleTime) { "Idle time incorrect" } },
+            { assertEquals(1478675712, monitor.activeTime) { "Active time incorrect" } },
+            { assertEquals(152, monitor.stealTime) { "Steal time incorrect" } },
             { assertEquals(0, monitor.lostTime) { "Lost time incorrect" } },
             { assertEquals(360369187, monitor.uptime) { "Uptime incorrect" } }
         )

--- a/opendc-experiments/opendc-experiments-greenifier/src/main/Python_scripts/OpenDCdemo.ipynb
+++ b/opendc-experiments/opendc-experiments-greenifier/src/main/Python_scripts/OpenDCdemo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "18170001",
    "metadata": {},
    "outputs": [],
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "a2d05361",
    "metadata": {},
    "outputs": [
@@ -165,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "fd17d88a",
    "metadata": {},
    "outputs": [
@@ -251,7 +251,7 @@
        "4  1019 2013-08-12 14:15:46+00:00    900000          1   0.000000"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -263,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "346f097f",
    "metadata": {
     "scrolled": true
@@ -364,7 +364,7 @@
        "4   2599.999649        179306  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -392,10 +392,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "0d400ffd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Addition/subtraction of integers and integer-arrays with Timestamp is no longer supported.  Instead of adding/subtracting `n`, use `n * obj.freq`",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[8], line 17\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21madd_absolute_timestamp\u001b[39m(df, start_dt):\n\u001b[1;32m     15\u001b[0m     df[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mabsolute_timestamp\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m start_dt \u001b[38;5;241m+\u001b[39m (df[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtimestamp\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m-\u001b[39m df[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtimestamp\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mmin())\n\u001b[0;32m---> 17\u001b[0m \u001b[43madd_absolute_timestamp\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdf_host_single\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdf_meta\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mstart_time\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmin\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     18\u001b[0m add_absolute_timestamp(df_host_single, df_meta[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstart_time\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mmin())\n\u001b[1;32m     20\u001b[0m add_absolute_timestamp(df_server_single, df_meta[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstart_time\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mmin())\n",
+      "Cell \u001b[0;32mIn[8], line 15\u001b[0m, in \u001b[0;36madd_absolute_timestamp\u001b[0;34m(df, start_dt)\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21madd_absolute_timestamp\u001b[39m(df, start_dt):\n\u001b[0;32m---> 15\u001b[0m     df[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mabsolute_timestamp\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[43mstart_dt\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[43m(\u001b[49m\u001b[43mdf\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mtimestamp\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m-\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mdf\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mtimestamp\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmin\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/ops/common.py:72\u001b[0m, in \u001b[0;36m_unpack_zerodim_and_defer.<locals>.new_method\u001b[0;34m(self, other)\u001b[0m\n\u001b[1;32m     68\u001b[0m             \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mNotImplemented\u001b[39m\n\u001b[1;32m     70\u001b[0m other \u001b[38;5;241m=\u001b[39m item_from_zerodim(other)\n\u001b[0;32m---> 72\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mmethod\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mother\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/arraylike.py:107\u001b[0m, in \u001b[0;36mOpsMixin.__radd__\u001b[0;34m(self, other)\u001b[0m\n\u001b[1;32m    105\u001b[0m \u001b[38;5;129m@unpack_zerodim_and_defer\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m__radd__\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__radd__\u001b[39m(\u001b[38;5;28mself\u001b[39m, other):\n\u001b[0;32m--> 107\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_arith_method\u001b[49m\u001b[43m(\u001b[49m\u001b[43mother\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mroperator\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mradd\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/series.py:6262\u001b[0m, in \u001b[0;36mSeries._arith_method\u001b[0;34m(self, other, op)\u001b[0m\n\u001b[1;32m   6260\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_arith_method\u001b[39m(\u001b[38;5;28mself\u001b[39m, other, op):\n\u001b[1;32m   6261\u001b[0m     \u001b[38;5;28mself\u001b[39m, other \u001b[38;5;241m=\u001b[39m ops\u001b[38;5;241m.\u001b[39malign_method_SERIES(\u001b[38;5;28mself\u001b[39m, other)\n\u001b[0;32m-> 6262\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mbase\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mIndexOpsMixin\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_arith_method\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mother\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mop\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/base.py:1325\u001b[0m, in \u001b[0;36mIndexOpsMixin._arith_method\u001b[0;34m(self, other, op)\u001b[0m\n\u001b[1;32m   1322\u001b[0m rvalues \u001b[38;5;241m=\u001b[39m ensure_wrapped_if_datetimelike(rvalues)\n\u001b[1;32m   1324\u001b[0m \u001b[38;5;28;01mwith\u001b[39;00m np\u001b[38;5;241m.\u001b[39merrstate(\u001b[38;5;28mall\u001b[39m\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mignore\u001b[39m\u001b[38;5;124m\"\u001b[39m):\n\u001b[0;32m-> 1325\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[43mops\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43marithmetic_op\u001b[49m\u001b[43m(\u001b[49m\u001b[43mlvalues\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mrvalues\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mop\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1327\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_construct_result(result, name\u001b[38;5;241m=\u001b[39mres_name)\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/ops/array_ops.py:218\u001b[0m, in \u001b[0;36marithmetic_op\u001b[0;34m(left, right, op)\u001b[0m\n\u001b[1;32m    205\u001b[0m \u001b[38;5;66;03m# NB: We assume that extract_array and ensure_wrapped_if_datetimelike\u001b[39;00m\n\u001b[1;32m    206\u001b[0m \u001b[38;5;66;03m#  have already been called on `left` and `right`,\u001b[39;00m\n\u001b[1;32m    207\u001b[0m \u001b[38;5;66;03m#  and `maybe_prepare_scalar_for_op` has already been called on `right`\u001b[39;00m\n\u001b[1;32m    208\u001b[0m \u001b[38;5;66;03m# We need to special-case datetime64/timedelta64 dtypes (e.g. because numpy\u001b[39;00m\n\u001b[1;32m    209\u001b[0m \u001b[38;5;66;03m# casts integer dtypes to timedelta64 when operating with timedelta64 - GH#22390)\u001b[39;00m\n\u001b[1;32m    211\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m (\n\u001b[1;32m    212\u001b[0m     should_extension_dispatch(left, right)\n\u001b[1;32m    213\u001b[0m     \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(right, (Timedelta, BaseOffset, Timestamp))\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    216\u001b[0m     \u001b[38;5;66;03m# Timedelta/Timestamp and other custom scalars are included in the check\u001b[39;00m\n\u001b[1;32m    217\u001b[0m     \u001b[38;5;66;03m# because numexpr will fail on it, see GH#31457\u001b[39;00m\n\u001b[0;32m--> 218\u001b[0m     res_values \u001b[38;5;241m=\u001b[39m \u001b[43mop\u001b[49m\u001b[43m(\u001b[49m\u001b[43mleft\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mright\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    219\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m    220\u001b[0m     \u001b[38;5;66;03m# TODO we should handle EAs consistently and move this check before the if/else\u001b[39;00m\n\u001b[1;32m    221\u001b[0m     \u001b[38;5;66;03m# (https://github.com/pandas-dev/pandas/issues/41165)\u001b[39;00m\n\u001b[1;32m    222\u001b[0m     _bool_arith_check(op, left, right)\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/roperator.py:11\u001b[0m, in \u001b[0;36mradd\u001b[0;34m(left, right)\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mradd\u001b[39m(left, right):\n\u001b[0;32m---> 11\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mright\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m+\u001b[39;49m\u001b[43m \u001b[49m\u001b[43mleft\u001b[49m\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/_libs/tslibs/timestamps.pyx:504\u001b[0m, in \u001b[0;36mpandas._libs.tslibs.timestamps._Timestamp.__add__\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: Addition/subtraction of integers and integer-arrays with Timestamp is no longer supported.  Instead of adding/subtracting `n`, use `n * obj.freq`"
+     ]
+    }
+   ],
    "source": [
     "output_folder = f\"{base_folder}/output\"\n",
     "workload = \"workload=bitbrains-small\"\n",
@@ -425,93 +445,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "a9a61332",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Index(['timestamp', 'host_id', 'cpu_count', 'mem_capacity',\n",
-       "       'guests_terminated', 'guests_running', 'guests_error', 'guests_invalid',\n",
-       "       'cpu_limit', 'cpu_usage', 'cpu_demand', 'cpu_utilization',\n",
-       "       'cpu_time_active', 'cpu_time_idle', 'cpu_time_steal', 'cpu_time_lost',\n",
-       "       'power_draw', 'energy_usage', 'uptime', 'downtime', 'boot_time',\n",
-       "       'absolute_timestamp'],\n",
-       "      dtype='object')"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "df_host_single.columns"
+    "df_host_single = pd.read_parquet(f\"{output_folder}/topology=single/{workload}/{seed}/host.parquet\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 27,
    "id": "d6fb41d9",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0        350.000000\n",
-       "1        350.000000\n",
-       "2        350.000000\n",
-       "3        291.779985\n",
-       "4        297.482719\n",
-       "            ...    \n",
-       "25918    267.445769\n",
-       "25919    276.532201\n",
-       "25920    263.564494\n",
-       "25921    273.482545\n",
-       "25922    200.000186\n",
-       "Name: power_draw, Length: 25923, dtype: float64"
+       "Timedelta('0 days 00:05:00')"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df_host_single.power_draw"
+    "pd.Timedelta(300000, unit=\"ms\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 30,
    "id": "3c271734",
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "0        105000.000000\n",
-       "1        105000.000000\n",
-       "2        105000.000000\n",
-       "3         87533.995628\n",
-       "4         89244.815826\n",
-       "             ...      \n",
-       "25918     79980.733894\n",
-       "25919     80669.879478\n",
-       "25920     82337.210297\n",
-       "25921     79545.414650\n",
-       "25922     68917.601292\n",
-       "Name: energy_usage, Length: 25923, dtype: float64"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "AttributeError",
+     "evalue": "Can only use .dt accessor with datetimelike values",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[30], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mdf_host_single\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtimestamp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdt\u001b[49m\u001b[38;5;241m.\u001b[39mto_pytimedelta()\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/generic.py:5907\u001b[0m, in \u001b[0;36mNDFrame.__getattr__\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m   5900\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m (\n\u001b[1;32m   5901\u001b[0m     name \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_internal_names_set\n\u001b[1;32m   5902\u001b[0m     \u001b[38;5;129;01mand\u001b[39;00m name \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_metadata\n\u001b[1;32m   5903\u001b[0m     \u001b[38;5;129;01mand\u001b[39;00m name \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_accessors\n\u001b[1;32m   5904\u001b[0m     \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_info_axis\u001b[38;5;241m.\u001b[39m_can_hold_identifiers_and_holds_name(name)\n\u001b[1;32m   5905\u001b[0m ):\n\u001b[1;32m   5906\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m[name]\n\u001b[0;32m-> 5907\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mobject\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[38;5;21;43m__getattribute__\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mname\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/accessor.py:183\u001b[0m, in \u001b[0;36mCachedAccessor.__get__\u001b[0;34m(self, obj, cls)\u001b[0m\n\u001b[1;32m    180\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m obj \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    181\u001b[0m     \u001b[38;5;66;03m# we're accessing the attribute of the class, i.e., Dataset.geo\u001b[39;00m\n\u001b[1;32m    182\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_accessor\n\u001b[0;32m--> 183\u001b[0m accessor_obj \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_accessor\u001b[49m\u001b[43m(\u001b[49m\u001b[43mobj\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    184\u001b[0m \u001b[38;5;66;03m# Replace the property with the accessor object. Inspired by:\u001b[39;00m\n\u001b[1;32m    185\u001b[0m \u001b[38;5;66;03m# https://www.pydanny.com/cached-property.html\u001b[39;00m\n\u001b[1;32m    186\u001b[0m \u001b[38;5;66;03m# We need to use object.__setattr__ because we overwrite __setattr__ on\u001b[39;00m\n\u001b[1;32m    187\u001b[0m \u001b[38;5;66;03m# NDFrame\u001b[39;00m\n\u001b[1;32m    188\u001b[0m \u001b[38;5;28mobject\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;21m__setattr__\u001b[39m(obj, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_name, accessor_obj)\n",
+      "File \u001b[0;32m~/.local/lib/python3.10/site-packages/pandas/core/indexes/accessors.py:513\u001b[0m, in \u001b[0;36mCombinedDatetimelikeProperties.__new__\u001b[0;34m(cls, data)\u001b[0m\n\u001b[1;32m    510\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m is_period_dtype(data\u001b[38;5;241m.\u001b[39mdtype):\n\u001b[1;32m    511\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m PeriodProperties(data, orig)\n\u001b[0;32m--> 513\u001b[0m \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mAttributeError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCan only use .dt accessor with datetimelike values\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "\u001b[0;31mAttributeError\u001b[0m: Can only use .dt accessor with datetimelike values"
+     ]
     }
    ],
    "source": [
-    "df_host_single.energy_usage"
+    "df_host_single.timestamp.to_pytimedelta()"
    ]
   },
   {

--- a/opendc-experiments/opendc-experiments-greenifier/src/test/kotlin/org/opendc/experiments/greenifier/GreenifierIntegrationTest.kt
+++ b/opendc-experiments/opendc-experiments-greenifier/src/test/kotlin/org/opendc/experiments/greenifier/GreenifierIntegrationTest.kt
@@ -120,9 +120,9 @@ class GreenifierIntegrationTest {
             { assertEquals(0, monitor.serversActive, "All VMs should finish after a run") },
             { assertEquals(0, monitor.attemptsFailure, "No VM should be unscheduled") },
             { assertEquals(0, monitor.serversPending, "No VM should not be in the queue") },
-            { assertEquals(223379987, monitor.idleTime) { "Incorrect idle time" } },
-            { assertEquals(66977088, monitor.activeTime) { "Incorrect active time" } },
-            { assertEquals(3160266, monitor.stealTime) { "Incorrect steal time" } },
+            { assertEquals(223379991650, monitor.idleTime) { "Incorrect idle time" } },
+            { assertEquals(66977091124, monitor.activeTime) { "Incorrect active time" } },
+            { assertEquals(3160267873, monitor.stealTime) { "Incorrect steal time" } },
             { assertEquals(0, monitor.lostTime) { "Incorrect lost time" } },
             { assertEquals(5.8407E9, monitor.energyUsage, 1E4) { "Incorrect power draw" } }
         )
@@ -160,9 +160,9 @@ class GreenifierIntegrationTest {
 
         // Note that these values have been verified beforehand
         assertAll(
-            { assertEquals(10996730, monitor.idleTime) { "Idle time incorrect" } },
-            { assertEquals(9741285, monitor.activeTime) { "Active time incorrect" } },
-            { assertEquals(0, monitor.stealTime) { "Steal time incorrect" } },
+            { assertEquals(10996730092, monitor.idleTime) { "Idle time incorrect" } },
+            { assertEquals(9741285381, monitor.activeTime) { "Active time incorrect" } },
+            { assertEquals(152, monitor.stealTime) { "Steal time incorrect" } },
             { assertEquals(0, monitor.lostTime) { "Lost time incorrect" } },
             { assertEquals(7.0109E8, monitor.energyUsage, 1E4) { "Incorrect power draw" } }
         )
@@ -199,10 +199,10 @@ class GreenifierIntegrationTest {
 
         // Note that these values have been verified beforehand
         assertAll(
-            { assertEquals(42814948, monitor.idleTime) { "Idle time incorrect" } },
-            { assertEquals(40138266, monitor.activeTime) { "Active time incorrect" } },
-            { assertEquals(23489356, monitor.stealTime) { "Steal time incorrect" } },
-            { assertEquals(424267, monitor.lostTime) { "Lost time incorrect" } }
+            { assertEquals(42814948316, monitor.idleTime) { "Idle time incorrect" } },
+            { assertEquals(40138266225, monitor.activeTime) { "Active time incorrect" } },
+            { assertEquals(23489356981, monitor.stealTime) { "Steal time incorrect" } },
+            { assertEquals(424267131, monitor.lostTime) { "Lost time incorrect" } }
         )
     }
 
@@ -229,9 +229,9 @@ class GreenifierIntegrationTest {
 
         // Note that these values have been verified beforehand
         assertAll(
-            { assertEquals(1404277, monitor.idleTime) { "Idle time incorrect" } },
-            { assertEquals(1478675, monitor.activeTime) { "Active time incorrect" } },
-            { assertEquals(0, monitor.stealTime) { "Steal time incorrect" } },
+            { assertEquals(1404277711, monitor.idleTime) { "Idle time incorrect" } },
+            { assertEquals(1478675712, monitor.activeTime) { "Active time incorrect" } },
+            { assertEquals(152, monitor.stealTime) { "Steal time incorrect" } },
             { assertEquals(0, monitor.lostTime) { "Lost time incorrect" } },
             { assertEquals(360369187, monitor.uptime) { "Uptime incorrect" } }
         )

--- a/site/docs/documentation/Output.md
+++ b/site/docs/documentation/Output.md
@@ -6,23 +6,23 @@ contains metrics describing the overall performance. An experiment in OpenDC has
 ### Server
 The server output file, contains all metrics of related to the servers run.  
 
-| Metric          | Datatype | Unit          | Summary                                                                       |
-|-----------------|----------|---------------|-------------------------------------------------------------------------------|
-| timestamp       | int64    | ms            | Timestamp of the sample                                                       |
-| server_id       | binary   | string        | The id of the server determined during runtime                                |
-| server_name     | binary   | string        | The name of the server provided by the Trace                                  |
-| host_id         | binary   | string        | The id of the host on which the server is hosted or `null` if it has no host. |
-| mem_capacity    | int64    | Mb            |                                                                               |
-| cpu_count       | int32    | count         |                                                                               |
-| cpu_limit       | double   | MHz           | The capacity of the CPUs of Host on which the server is running.              |
-| cpu_time_active | int64    | seconds       | The duration that a CPU was active in the server.                             |
-| cpu_time_idle   | int64    | seconds       | The duration that a CPU was idle in the server.                               |
-| cpu_time_steal  | int64    | seconds       | The duration that a vCPU wanted to run, but no capacity was available.        |
-| cpu_time_lost   | int64    | seconds       | The duration of CPU time that was lost due to interference.                   |
-| uptime          | int64    | milli seconds | The uptime of the host since last sample.                                     |
-| downtime        | int64    | milli seconds | The downtime of the host since last sample.                                   |
-| provision_time  | int64    | ms            | The time for which the server was enqueued for the scheduler.                 |
-| boot_time       | int64    | ms            | The time the server took booting.                                             |
+| Metric          | Datatype | Unit   | Summary                                                                       |
+|-----------------|----------|--------|-------------------------------------------------------------------------------|
+| timestamp       | int64    | ms     | Timestamp of the sample                                                       |
+| server_id       | binary   | string | The id of the server determined during runtime                                |
+| server_name     | binary   | string | The name of the server provided by the Trace                                  |
+| host_id         | binary   | string | The id of the host on which the server is hosted or `null` if it has no host. |
+| mem_capacity    | int64    | Mb     |                                                                               |
+| cpu_count       | int32    | count  |                                                                               |
+| cpu_limit       | double   | MHz    | The capacity of the CPUs of Host on which the server is running.              |
+| cpu_time_active | int64    | ms     | The duration that a CPU was active in the server.                             |
+| cpu_time_idle   | int64    | ms     | The duration that a CPU was idle in the server.                               |
+| cpu_time_steal  | int64    | ms     | The duration that a vCPU wanted to run, but no capacity was available.        |
+| cpu_time_lost   | int64    | ms     | The duration of CPU time that was lost due to interference.                   |
+| uptime          | int64    | ms     | The uptime of the host since last sample.                                     |
+| downtime        | int64    | ms     | The downtime of the host since last sample.                                   |
+| provision_time  | int64    | ms     | The time for which the server was enqueued for the scheduler.                 |
+| boot_time       | int64    | ms     | The time the server took booting.                                             |
 
 ### Host
 The host output file, contains all metrics of related to the host run.

--- a/site/docs/documentation/Output.md
+++ b/site/docs/documentation/Output.md
@@ -8,59 +8,59 @@ The server output file, contains all metrics of related to the servers run.
 
 | Metric          | Datatype | Unit          | Summary                                                                       |
 |-----------------|----------|---------------|-------------------------------------------------------------------------------|
-| timestamp       | int      | datetime      | Timestamp of the sample                                                       |
-| server_id       | string   |               | The id of the server determined during runtime                                |
-| server_name     | string   |               | The name of the server provided by the Trace                                  |
-| host_id         | string   |               | The id of the host on which the server is hosted or `null` if it has no host. |
-| mem_capacity    | int      | Mb            |                                                                               |
-| cpu_count       | int      | count         |                                                                               |
-| cpu_limit       | float    | MHz           | The capacity of the CPUs of Host on which the server is running.              |
-| cpu_time_active | int      | seconds       | The duration that a CPU was active in the server.                             |
-| cpu_time_idle   | int      | seconds       | The duration that a CPU was idle in the server.                               |
-| cpu_time_steal  | int      | seconds       | The duration that a vCPU wanted to run, but no capacity was available.        |
-| cpu_time_lost   | int      | seconds       | The duration of CPU time that was lost due to interference.                   |
-| uptime          | int      | milli seconds | The uptime of the host since last sample.                                     |
-| downtime        | int      | milli seconds | The downtime of the host since last sample.                                   |
-| provision_time  | int      | datetime      | The time at which the server was enqueued for the scheduler.                  |
-| boot_time       | int      | datetime      | The time at which the server booted.                                          |
+| timestamp       | int64    | ms            | Timestamp of the sample                                                       |
+| server_id       | binary   | string        | The id of the server determined during runtime                                |
+| server_name     | binary   | string        | The name of the server provided by the Trace                                  |
+| host_id         | binary   | string        | The id of the host on which the server is hosted or `null` if it has no host. |
+| mem_capacity    | int64    | Mb            |                                                                               |
+| cpu_count       | int32    | count         |                                                                               |
+| cpu_limit       | double   | MHz           | The capacity of the CPUs of Host on which the server is running.              |
+| cpu_time_active | int64    | seconds       | The duration that a CPU was active in the server.                             |
+| cpu_time_idle   | int64    | seconds       | The duration that a CPU was idle in the server.                               |
+| cpu_time_steal  | int64    | seconds       | The duration that a vCPU wanted to run, but no capacity was available.        |
+| cpu_time_lost   | int64    | seconds       | The duration of CPU time that was lost due to interference.                   |
+| uptime          | int64    | milli seconds | The uptime of the host since last sample.                                     |
+| downtime        | int64    | milli seconds | The downtime of the host since last sample.                                   |
+| provision_time  | int64    | ms            | The time for which the server was enqueued for the scheduler.                 |
+| boot_time       | int64    | ms            | The time the server took booting.                                             |
 
 ### Host
 The host output file, contains all metrics of related to the host run.
 
-| Metric            | DataType | Unit          | Summary                                                                                         |
-|-------------------|----------|---------------|-------------------------------------------------------------------------------------------------|
-| timestamp         | int      | datetime      | Timestamp of the sample                                                                         |
-| host_id           | string   |               | The id of the host given by OpenDC                                                              |
-| cpu_count         | int      | count         | The number of available cpu cores                                                               |
-| mem_capacity      | int      | Mb            | The amount of available memory                                                                  |
-| guests_terminated | int      | count         | The number of guests that are in a terminated state.                                            |
-| guests_running    | int      | count         | The number of guests that are in a running state.                                               |
-| guests_error      | int      | count         | The number of guests that are in an error state.                                                |
-| guests_invalid    | int      | count         | The number of guests that are in an unknown state.                                              |
-| cpu_limit         | float    | MHz           | The capacity of the CPUs in the host.                                                           |
-| cpu_usage         | float    | MHz           | The usage of all CPUs in the host.                                                              |
-| cpu_demand        | float    | MHz           | The demand of all vCPUs of the guests                                                           |
-| cpu_utilization   | float    | ratio         | The CPU utilization of the host. This is calculated by dividing the cpu_usage, by the cpu_limit |
-| cpu_time_active   | int      | seconds       | The duration that a CPU was active in the host.                                                 |
-| cpu_time_idle     | int      | seconds       | The duration that a CPU was idle in the host.                                                   |
-| cpu_time_steal    | int      | seconds       | The duration that a vCPU wanted to run, but no capacity was available.                          |
-| cpu_time_lost     | int      | seconds       | The duration of CPU time that was lost due to interference.                                     |
-| power_draw        | float    | Watt          | The current power draw of the host.                                                             |
-| energy_usage      | float    | Joule (Ws)    | he total energy consumption of the host since last sample.                                      |
-| uptime            | int      | milli seconds | The uptime of the host since last sample.                                                       |
-| downtime          | int      | milli seconds | The downtime of the host since last sample.                                                     |
-| boot_time         | int      | datetime      | The timestamp at which the host booted.                                                         |
+| Metric            | DataType | Unit       | Summary                                                                                         |
+|-------------------|----------|------------|-------------------------------------------------------------------------------------------------|
+| timestamp         | int64    | ms         | Timestamp of the sample                                                                         |
+| host_id           | binary   | string     | The id of the host given by OpenDC                                                              |
+| cpu_count         | int32    | count      | The number of available cpu cores                                                               |
+| mem_capacity      | int64    | Mb         | The amount of available memory                                                                  |
+| guests_terminated | int32    | count      | The number of guests that are in a terminated state.                                            |
+| guests_running    | int32    | count      | The number of guests that are in a running state.                                               |
+| guests_error      | int32    | count      | The number of guests that are in an error state.                                                |
+| guests_invalid    | int32    | count      | The number of guests that are in an unknown state.                                              |
+| cpu_limit         | double   | MHz        | The capacity of the CPUs in the host.                                                           |
+| cpu_usage         | double   | MHz        | The usage of all CPUs in the host.                                                              |
+| cpu_demand        | double   | MHz        | The demand of all vCPUs of the guests                                                           |
+| cpu_utilization   | double   | ratio      | The CPU utilization of the host. This is calculated by dividing the cpu_usage, by the cpu_limit |
+| cpu_time_active   | int64    | ms         | The duration that a CPU was active in the host.                                                 |
+| cpu_time_idle     | int64    | ms         | The duration that a CPU was idle in the host.                                                   |
+| cpu_time_steal    | int64    | ms         | The duration that a vCPU wanted to run, but no capacity was available.                          |
+| cpu_time_lost     | int64    | ms         | The duration of CPU time that was lost due to interference.                                     |
+| power_draw        | double   | Watt       | The current power draw of the host.                                                             |
+| energy_usage      | double   | Joule (Ws) | he total energy consumption of the host since last sample.                                      |
+| uptime            | int64    | ms         | The uptime of the host since last sample.                                                       |
+| downtime          | int64    | ms         | The downtime of the host since last sample.                                                     |
+| boot_time         | int64    | ms         | The time the host took to boot.                                                                 |
 
 ### Service
 The service output file, contains metrics providing an overview of the performance.
 
-| Metric           | DataType | Unit     | Summary                                                                |
-|------------------|----------|----------|------------------------------------------------------------------------|
-| timestamp        | int      | datetime | Timestamp of the sample                                                |
-| hosts_up         | int      | count    | The number of hosts that are up at this instant.                       |
-| hosts_down       | int      | count    | The number of hosts that are down at this instant.                     |
-| servers_pending  | int      | count    | The number of servers that are pending to be scheduled.                |
-| servers_active   | int      | count    | The number of servers that are currently active.                       |
-| attempts_success | int      | count    | The scheduling attempts that were successful.                          |
-| attempts_failure | int      | count    | The scheduling attempts that were unsuccessful due to client error.    |
-| attempts_error   | int      | count    | The scheduling attempts that were unsuccessful due to scheduler error. |
+| Metric           | DataType | Unit  | Summary                                                                |
+|------------------|----------|-------|------------------------------------------------------------------------|
+| timestamp        | int64    | ms    | Timestamp of the sample                                                |
+| hosts_up         | int32    | count | The number of hosts that are up at this instant.                       |
+| hosts_down       | int32    | count | The number of hosts that are down at this instant.                     |
+| servers_pending  | int32    | count | The number of servers that are pending to be scheduled.                |
+| servers_active   | int32    | count | The number of servers that are currently active.                       |
+| attempts_success | int32    | count | The scheduling attempts that were successful.                          |
+| attempts_failure | int32    | count | The scheduling attempts that were unsuccessful due to client error.    |
+| attempts_error   | int32    | count | The scheduling attempts that were unsuccessful due to scheduler error. |


### PR DESCRIPTION
## Summary

Changed the type of multiple metrics. 

## Implementation Notes :hammer_and_pick:

- All metrics that measure time, such as cpu_time_active or uptime are now in milliseconds. 
- All timestamps are converted to milliseconds as well. 

## External Dependencies :four_leaf_clover:

N/A

## Breaking API Changes :warning:

1. Experiments might expect datetime object when loading into something like pandas. This will not work with the new int type, but should be easy to update
2. Some metrics will result in values 1000 * higher because they are converted from seconds to milliseconds. 


*Simply specify none (N/A) if not applicable.*