### PR TITLE
returned the carbon traces to the scenarioSpec

### DIFF
--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/models/scenario/Scenario.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/models/scenario/Scenario.kt
@@ -46,6 +46,7 @@ public data class Scenario(
     val workload: WorkloadSpec,
     val allocationPolicy: AllocationPolicySpec,
     val failureModel: FailureModel?,
+    val carbonTracePath: String? = null,
     val exportModel: ExportModelSpec = ExportModelSpec(),
     val outputFolder: String = "output",
     val name: String = "",

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/models/scenario/ScenarioFactories.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/models/scenario/ScenarioFactories.kt
@@ -31,7 +31,6 @@ import org.opendc.compute.topology.clusterTopology
 import org.opendc.compute.topology.specs.TopologyJSONSpec
 import org.opendc.experiments.base.models.scenario.specs.ScenarioSpec
 import java.io.File
-import java.util.UUID
 
 private val scenarioReader = ScenarioReader()
 
@@ -73,7 +72,6 @@ public fun getScenario(scenarioSpec: ScenarioSpec): List<Scenario> {
  * @return A list of Scenarios.
  */
 public fun getScenarioCombinations(scenarioSpec: ScenarioSpec): List<Scenario> {
-    val topologies = getTopologies(scenarioSpec.topologies)
     val topologiesSpec = scenarioSpec.topologies
     val workloads = scenarioSpec.workloads
     val allocationPolicies = scenarioSpec.allocationPolicies
@@ -85,20 +83,23 @@ public fun getScenarioCombinations(scenarioSpec: ScenarioSpec): List<Scenario> {
         for (workload in workloads) {
             for (allocationPolicy in allocationPolicies) {
                 for (failureModel in failureModels) {
-                    for (exportModel in exportModels) {
-                        val scenario =
-                            Scenario(
-                                topology = clusterTopology(File(topology.pathToFile)),
-                                workload = workload,
-                                allocationPolicy = allocationPolicy,
-                                failureModel = getFailureModel(failureModel.failureInterval),
-                                exportModel = exportModel,
-                                outputFolder = scenarioSpec.outputFolder,
-                                name = getOutputFolderName(scenarioSpec, topology, workload, allocationPolicy),
-                                runs = scenarioSpec.runs,
-                                initialSeed = scenarioSpec.initialSeed,
-                            )
-                        scenarios.add(scenario)
+                    for (carbonTracePath in scenarioSpec.carbonTracePaths) {
+                        for (exportModel in exportModels) {
+                            val scenario =
+                                Scenario(
+                                    topology = clusterTopology(File(topology.pathToFile)),
+                                    workload = workload,
+                                    allocationPolicy = allocationPolicy,
+                                    failureModel = getFailureModel(failureModel.failureInterval),
+                                    carbonTracePath = carbonTracePath,
+                                    exportModel = exportModel,
+                                    outputFolder = scenarioSpec.outputFolder,
+                                    name = getOutputFolderName(scenarioSpec, topology, workload, allocationPolicy),
+                                    runs = scenarioSpec.runs,
+                                    initialSeed = scenarioSpec.initialSeed,
+                                )
+                            scenarios.add(scenario)
+                        }
                     }
                 }
             }
@@ -139,8 +140,7 @@ public fun getOutputFolderName(
     allocationPolicy: AllocationPolicySpec,
 ): String {
     return "scenario=${scenarioSpec.name}" +
-        "-topology=${topology.pathToFile}" +
-        "-workload=${workload.name}}" +
-        "-scheduler=${allocationPolicy.name}" +
-        "-${UUID.randomUUID().toString().substring(0, 8)}"
+        "-topology=${topology.name}" +
+        "-workload=${workload.name}" +
+        "-scheduler=${allocationPolicy.name}"
 }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/models/scenario/specs/ScenarioSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/models/scenario/specs/ScenarioSpec.kt
@@ -47,6 +47,7 @@ public data class ScenarioSpec(
     val workloads: List<WorkloadSpec>,
     val allocationPolicies: List<AllocationPolicySpec>,
     val failureModels: List<FailureModelSpec> = listOf(FailureModelSpec()),
+    val carbonTracePaths: List<String?> = listOf(null),
     val exportModels: List<ExportModelSpec> = listOf(ExportModelSpec()),
     val outputFolder: String = "output",
     val initialSeed: Int = 0,
@@ -57,6 +58,7 @@ public data class ScenarioSpec(
         require(runs > 0) { "The number of runs should always be positive" }
 
         // generate name if not provided
+        // TODO: improve this
         if (name == "") {
             name =
                 "workload=${workloads[0].name}_topology=${topologies[0].name}_allocationPolicy=${allocationPolicies[0].name}"


### PR DESCRIPTION
## Summary

In a previous PR, the carbon trace argument was removed from the scenario.
This PR returns it.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*