### PR TITLE
Fixed typo in gradle build file that caused the distribution to not run.

### DIFF
--- a/opendc-experiments/opendc-experiments-base/build.gradle.kts
+++ b/opendc-experiments/opendc-experiments-base/build.gradle.kts
@@ -56,7 +56,7 @@ val createScenarioApp by tasks.creating(CreateStartScripts::class) {
     dependsOn(tasks.jar)
 
     applicationName = "OpenDCScenarioRunner"
-    mainClass.set("org.opendc.experiments.base.ScenarioCLI")
+    mainClass.set("org.opendc.experiments.base.runner.ScenarioCli")
     classpath = tasks.jar.get().outputs.files + configurations["runtimeClasspath"]
     outputDir = project.buildDir.resolve("scripts")
 }


### PR DESCRIPTION
## Summary

Fixed typo in gradle build file that caused the distribution to not run.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*