### PR TITLE
updated ScenarioFactory and ScenarioSpec

### DIFF
--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioReplayer.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioReplayer.kt
@@ -24,7 +24,6 @@
 
 package org.opendc.experiments.base.runner
 
-import CheckpointModelSpec
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -36,6 +35,7 @@ import org.opendc.compute.api.ServerWatcher
 import org.opendc.compute.failure.models.FailureModel
 import org.opendc.compute.service.ComputeService
 import org.opendc.compute.workload.VirtualMachine
+import org.opendc.experiments.base.scenario.specs.CheckpointModelSpec
 import org.opendc.experiments.base.scenario.specs.FailureModelSpec
 import org.opendc.experiments.base.scenario.specs.createFailureModel
 import java.time.InstantSource

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
@@ -35,6 +35,7 @@ import org.opendc.compute.simulator.provisioner.setupHosts
 import org.opendc.compute.telemetry.export.parquet.ParquetComputeMonitor
 import org.opendc.compute.topology.clusterTopology
 import org.opendc.compute.workload.ComputeWorkloadLoader
+import org.opendc.experiments.base.scenario.specs.getWorkloadType
 import org.opendc.experiments.base.scenario.Scenario
 import org.opendc.simulator.kotlin.runSimulation
 import java.io.File

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
@@ -22,7 +22,6 @@
 
 package org.opendc.experiments.base.runner
 
-import getWorkloadType
 import me.tongfei.progressbar.ProgressBarBuilder
 import me.tongfei.progressbar.ProgressBarStyle
 import org.opendc.compute.carbon.CarbonTrace
@@ -60,7 +59,7 @@ public fun runScenarios(
 
     setupOutputFolderStructure(scenarios[0].outputFolder)
 
-    for ((i, scenario) in scenarios.withIndex()) {
+    for (scenario in scenarios) {
         val pool = ForkJoinPool(parallelism)
         println(
             "\n\n$ansiGreen================================================================================$ansiReset",
@@ -70,7 +69,6 @@ public fun runScenarios(
         runScenario(
             scenario,
             pool,
-            i,
         )
     }
 }
@@ -85,7 +83,6 @@ public fun runScenarios(
 public fun runScenario(
     scenario: Scenario,
     pool: ForkJoinPool,
-    index: Int = -1,
 ) {
     val pb =
         ProgressBarBuilder().setInitialMax(scenario.runs.toLong()).setStyle(ProgressBarStyle.ASCII)
@@ -93,7 +90,7 @@ public fun runScenario(
 
     pool.submit {
         LongStream.range(0, scenario.runs.toLong()).parallel().forEach {
-            runScenario(scenario, scenario.initialSeed + it, index)
+            runScenario(scenario, scenario.initialSeed + it)
             pb.step()
         }
         pb.close()
@@ -108,8 +105,7 @@ public fun runScenario(
  */
 public fun runScenario(
     scenario: Scenario,
-    seed: Long,
-    index: Int = 0,
+    seed: Long
 ): Unit =
     runSimulation {
         val serviceDomain = "compute.opendc.org"
@@ -129,7 +125,7 @@ public fun runScenario(
 
             val carbonTrace = getCarbonTrace(scenario.carbonTracePath)
             val startTime = Duration.ofMillis(vms.minOf { it.startTime }.toEpochMilli())
-            addExportModel(provisioner, serviceDomain, scenario, seed, startTime, carbonTrace, index)
+            addExportModel(provisioner, serviceDomain, scenario, seed, startTime, carbonTrace, scenario.id)
 
             val service = provisioner.registry.resolve(serviceDomain, ComputeService::class.java)!!
             service.replay(timeSource, vms, failureModelSpec = scenario.failureModelSpec, seed = seed)

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/Scenario.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/Scenario.kt
@@ -22,12 +22,13 @@
 
 package org.opendc.experiments.base.scenario
 
-import AllocationPolicySpec
-import CheckpointModelSpec
-import ExportModelSpec
-import ScenarioTopologySpec
-import WorkloadSpec
+
+import org.opendc.experiments.base.scenario.specs.ScenarioTopologySpec
+import org.opendc.experiments.base.scenario.specs.WorkloadSpec
+import org.opendc.experiments.base.scenario.specs.AllocationPolicySpec
 import org.opendc.experiments.base.scenario.specs.FailureModelSpec
+import org.opendc.experiments.base.scenario.specs.CheckpointModelSpec
+import org.opendc.experiments.base.scenario.specs.ExportModelSpec
 
 /**
  * A data class representing a scenario for a set of experiments.

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/ScenarioFactories.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/ScenarioFactories.kt
@@ -83,7 +83,7 @@ public fun getScenarios(scenariosSpec: ScenariosSpec): List<Scenario> {
                 runs = scenariosSpec.runs,
                 initialSeed = scenariosSpec.initialSeed,
             )
-        trackScenario(scenarioSpec, outputFolder, scenario)
+        trackScenario(scenarioSpec, outputFolder)
         scenarios.add(scenario)
     }
 
@@ -101,8 +101,7 @@ public fun getScenarios(scenariosSpec: ScenariosSpec): List<Scenario> {
  */
 public fun trackScenario(
     scenarioSpec: ScenarioSpec,
-    outputFolder: String,
-    scenario: Scenario,
+    outputFolder: String
 ) {
     val trackrPath = "$outputFolder/trackr.json"
     scenarioWriter.write(
@@ -113,18 +112,3 @@ public fun trackScenario(
     // remove the last comma
     File(trackrPath).writeText(File(trackrPath).readText().dropLast(3) + "]")
 }
-
-//        ScenariosSpec(
-//            id = scenario.id,
-//            name = scenariosSpec.name,
-//            topologies = setOf(scenario.topologySpec),
-//            workloads = setOf(scenario.workloadSpec),
-//            allocationPolicies = setOf(scenario.allocationPolicySpec),
-//            failureModels = setOf(scenario.failureModelSpec),
-//            checkpointModels = setOf(scenario.checkpointModelSpec),
-//            carbonTracePaths = setOf(scenario.carbonTracePath),
-//            exportModels = setOf(scenario.exportModelSpec),
-//            outputFolder = scenario.outputFolder,
-//            initialSeed = scenario.initialSeed,
-//            runs = scenario.runs,
-//        ),

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/ScenarioFactories.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/ScenarioFactories.kt
@@ -77,7 +77,7 @@ public fun getScenarios(scenariosSpec: ScenariosSpec): List<Scenario> {
                 failureModelSpec = scenarioSpec.failureModel,
                 checkpointModelSpec = scenarioSpec.checkpointModel,
                 carbonTracePath = scenarioSpec.carbonTracePath,
-                exportModelSpec = scenarioSpec.carbonTracePath,
+                exportModelSpec = scenarioSpec.exportModel,
                 outputFolder = outputFolder,
                 name = scenarioID.toString(),
                 runs = scenariosSpec.runs,

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/ScenarioReader.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/ScenarioReader.kt
@@ -25,7 +25,7 @@ package org.opendc.experiments.base.scenario
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
-import org.opendc.experiments.base.scenario.specs.ScenarioSpec
+import org.opendc.experiments.base.scenario.specs.ScenariosSpec
 import java.io.File
 import java.io.InputStream
 import java.nio.file.Path
@@ -36,24 +36,24 @@ public class ScenarioReader {
     private val jsonReader = Json
 
     @OptIn(ExperimentalSerializationApi::class)
-    public fun read(file: File): ScenarioSpec {
+    public fun read(file: File): ScenariosSpec {
         val input = file.inputStream()
 
-        return jsonReader.decodeFromStream<ScenarioSpec>(input)
+        return jsonReader.decodeFromStream<ScenariosSpec>(input)
     }
 
     @OptIn(ExperimentalSerializationApi::class)
-    public fun read(path: Path): ScenarioSpec {
+    public fun read(path: Path): ScenariosSpec {
         val input = path.inputStream()
 
-        return jsonReader.decodeFromStream<ScenarioSpec>(input)
+        return jsonReader.decodeFromStream<ScenariosSpec>(input)
     }
 
     /**
      * Read the specified [input].
      */
     @OptIn(ExperimentalSerializationApi::class)
-    public fun read(input: InputStream): ScenarioSpec {
-        return jsonReader.decodeFromStream<ScenarioSpec>(input)
+    public fun read(input: InputStream): ScenariosSpec {
+        return jsonReader.decodeFromStream<ScenariosSpec>(input)
     }
 }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/ScenarioWriter.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/ScenarioWriter.kt
@@ -37,7 +37,7 @@ public class ScenarioWriter {
     private val json = Json { prettyPrint = true }
 
     /**
-     * Write the given [scenarioSpec] to the given [file].
+     * Write the given [scenariosSpec] to the given [file].
      */
     public fun write(
         scenarioSpec: ScenarioSpec,

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/AllocationPolicySpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/AllocationPolicySpec.kt
@@ -34,7 +34,7 @@ import org.opendc.compute.service.scheduler.ComputeSchedulerEnum
  */
 @Serializable
 public data class AllocationPolicySpec(
-    val policyType: ComputeSchedulerEnum,
+    val policyType: ComputeSchedulerEnum = ComputeSchedulerEnum.Mem,
 ) {
     public val name: String = policyType.toString()
 }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/AllocationPolicySpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/AllocationPolicySpec.kt
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+package org.opendc.experiments.base.scenario.specs
+
 import kotlinx.serialization.Serializable
 import org.opendc.compute.service.scheduler.ComputeSchedulerEnum
 

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/CheckpointModelSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/CheckpointModelSpec.kt
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+package org.opendc.experiments.base.scenario.specs
+
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/ExportModelSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/ExportModelSpec.kt
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+package org.opendc.experiments.base.scenario.specs
+
 import kotlinx.serialization.Serializable
 
 /**

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/PowerModelSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/PowerModelSpec.kt
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+package org.opendc.experiments.base.scenario.specs
+
 import kotlinx.serialization.Serializable
 
 @Serializable

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/ScenarioSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/ScenarioSpec.kt
@@ -22,11 +22,6 @@
 
 package org.opendc.experiments.base.scenario.specs
 
-import AllocationPolicySpec
-import CheckpointModelSpec
-import ExportModelSpec
-import ScenarioTopologySpec
-import WorkloadSpec
 import kotlinx.serialization.Serializable
 import java.util.UUID
 
@@ -46,13 +41,13 @@ import java.util.UUID
 public data class ScenarioSpec(
     var id: Int = -1,
     var name: String = "",
-    val topologies: List<ScenarioTopologySpec>,
-    val workloads: List<WorkloadSpec>,
-    val allocationPolicies: List<AllocationPolicySpec>,
-    val failureModels: List<FailureModelSpec?> = listOf(null),
-    val checkpointModels: List<CheckpointModelSpec?> = listOf(null),
-    val carbonTracePaths: List<String?> = listOf(null),
-    val exportModels: List<ExportModelSpec> = listOf(ExportModelSpec()),
+    val topologies: Set<ScenarioTopologySpec>,
+    val workloads: Set<WorkloadSpec>,
+    val allocationPolicies: Set<AllocationPolicySpec>,
+    val failureModels: Set<FailureModelSpec?> = setOf(null),
+    val checkpointModels: Set<CheckpointModelSpec?> = setOf(null),
+    val carbonTracePaths: Set<String?> = setOf(null),
+    val exportModels: Set<ExportModelSpec> = setOf(ExportModelSpec()),
     val outputFolder: String = "output",
     val initialSeed: Int = 0,
     val runs: Int = 1,

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/ScenarioTopologySpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/ScenarioTopologySpec.kt
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+package org.opendc.experiments.base.scenario.specs
+
 import kotlinx.serialization.Serializable
 import java.io.File
 

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/ScenariosSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/ScenariosSpec.kt
@@ -83,31 +83,38 @@ public data class ScenariosSpec(
 
     public fun getCartesian(): Sequence<ScenarioSpec> {
         return sequence {
-            val checkpoint_div = carbonTracePaths.size
-            val failure_div = checkpoint_div * checkpointModels.size
-            val export_div = failure_div * failureModels.size
-            val allocation_div = export_div * exportModels.size
-            val workload_div = allocation_div * allocationPolicies.size
-            val topology_div = workload_div * workloads.size
-            val num_scenarios = topology_div * topologies.size
+            val checkpointDiv = carbonTracePaths.size
+            val failureDiv = checkpointDiv * checkpointModels.size
+            val exportDiv = failureDiv * failureModels.size
+            val allocationDiv = exportDiv * exportModels.size
+            val workloadDiv = allocationDiv * allocationPolicies.size
+            val topologyDiv = workloadDiv * workloads.size
+            val numScenarios = topologyDiv * topologies.size
 
-            for (i in 0 until num_scenarios) {
+            val topologyList = topologies.toList()
+            val workloadList = workloads.toList()
+            val allocationPolicyList = allocationPolicies.toList()
+            val exportModelList = exportModels.toList()
+            val failureModelList = failureModels.toList()
+            val checkpointModelList = checkpointModels.toList()
+            val carbonTracePathList = carbonTracePaths.toList()
+
+            for (i in 0 until numScenarios) {
                 yield(
                     ScenarioSpec(
                         id,
                         name,
                         outputFolder,
-                        topologies.toList()[(i/topology_div) % topologies.size],
-                        workloads.toList()[(i/workload_div) % workloads.size],
-                        allocationPolicies.toList()[(i/allocation_div) % allocationPolicies.size],
-                        exportModels.toList()[(i/export_div) % exportModels.size],
-                        failureModels.toList()[(i/failure_div) % failureModels.size],
-                        checkpointModels.toList()[(i/checkpoint_div) % checkpointModels.size],
-                        carbonTracePaths.toList()[i % carbonTracePaths.size]
+                        topologyList[(i/topologyDiv) % topologyList.size],
+                        workloadList[(i/workloadDiv) % workloadList.size],
+                        allocationPolicyList[(i/allocationDiv) % allocationPolicyList.size],
+                        exportModelList[(i/exportDiv) % exportModelList.size],
+                        failureModelList[(i/failureDiv) % failureModelList.size],
+                        checkpointModelList[(i/checkpointDiv) % checkpointModelList.size],
+                        carbonTracePathList[i % carbonTracePathList.size]
                     )
                 )
             }
         }
     }
-
 }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/WorkloadSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/scenario/specs/WorkloadSpec.kt
@@ -20,6 +20,8 @@
  * SOFTWARE.
  */
 
+package org.opendc.experiments.base.scenario.specs
+
 import kotlinx.serialization.Serializable
 import org.opendc.compute.workload.ComputeWorkload
 import org.opendc.compute.workload.sampleByLoad


### PR DESCRIPTION
## Summary

Updated the way the scenarios are generated from a scenario JSON file. 
The function getCartesian() is added to ScenariosSpec which creates a sequence of scenarios using the cartesian product. 
This removes the nested for loop in ScenarioRunner.

## Implementation Notes :hammer_and_pick:


## External Dependencies :four_leaf_clover:


## Breaking API Changes :warning:


*Simply specify none (N/A) if not applicable.*