### PR TITLE
Updated SimTrace implementation

### DIFF
--- a/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/hostfault/StartStopHostFault.kt
+++ b/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/hostfault/StartStopHostFault.kt
@@ -43,7 +43,8 @@ public class StartStopHostFault(
         for (host in victims) {
             val servers = host.instances
 
-            val snapshots = servers.map { (it.meta["workload"] as SimWorkload).snapshot() }
+            val sortedServers = servers.sortedBy { it.name }
+            val snapshots = sortedServers.map { (it.meta["workload"] as SimWorkload).snapshot() }
             host.fail()
 
             for ((server, snapshot) in servers.zip(snapshots)) {

--- a/opendc-experiments/opendc-experiments-faas/src/main/kotlin/org/opendc/experiments/faas/FunctionTraceWorkload.kt
+++ b/opendc-experiments/opendc-experiments-faas/src/main/kotlin/org/opendc/experiments/faas/FunctionTraceWorkload.kt
@@ -34,7 +34,7 @@ public class FunctionTraceWorkload(trace: FunctionTrace) :
     SimFaaSWorkload,
     SimWorkload by SimTrace.ofFragments(
         trace.samples.map {
-            SimTraceFragment(it.timestamp, it.duration, it.cpuUsage, 1)
+            SimTraceFragment(it.timestamp + it.duration, it.cpuUsage, 1)
         },
     ).createWorkload(0) {
     override suspend fun invoke() {}

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimTraceFragment.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimTraceFragment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 AtLarge Research
+ * Copyright (c) 2024 AtLarge Research
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,73 +22,9 @@
 
 package org.opendc.simulator.compute.workload;
 
-import java.util.Objects;
+public record SimTraceFragment(long deadline, double cpuUsage, int coreCount) {
 
-/**
- * A fragment of the workload trace.
- */
-public final class SimTraceFragment {
-    final long timestamp;
-    final long duration;
-    final double usage;
-    final int cores;
-
-    /**
-     * Construct a {@link SimTraceFragment}.
-     *
-     * @param timestamp The timestamp at which the fragment starts (in epoch millis).
-     * @param duration The duration of the fragment (in milliseconds).
-     * @param usage The CPU usage during the fragment (in MHz).
-     * @param cores The amount of cores utilized during the fragment.
-     */
-    public SimTraceFragment(long timestamp, long duration, double usage, int cores) {
-        this.timestamp = timestamp;
-        this.duration = duration;
-        this.usage = usage;
-        this.cores = cores;
-    }
-
-    /**
-     * Return the timestamp at which the fragment starts (in epoch millis).
-     */
-    public long getTimestamp() {
-        return timestamp;
-    }
-
-    /**
-     * Return the duration of the fragment (in milliseconds).
-     */
-    public long getDuration() {
-        return duration;
-    }
-
-    /**
-     * Return the CPU usage during the fragment (in MHz).
-     */
-    public double getUsage() {
-        return usage;
-    }
-
-    /**
-     * Return the amount of cores utilized during the fragment.
-     */
-    public int getCores() {
-        return cores;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SimTraceFragment that = (SimTraceFragment) o;
-        return timestamp == that.timestamp
-                && duration == that.duration
-                && Double.compare(that.usage, usage) == 0
-                && cores == that.cores;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(timestamp, duration, usage, cores);
+    public SimTraceFragment(long start, long duration, double cpuUsage, int coreCount) {
+        this(start + duration, cpuUsage, coreCount);
     }
 }


### PR DESCRIPTION
Updated SimTrace to use a single ArrayDeque instead of three separate lists for deadline, cpuUsage, and coreCount

## Summary

A small summary of the requirements (in one/two sentences).

## Implementation Notes :hammer_and_pick:

* Briefly outline the overall technical solution. If necessary, identify talking points where the reviewer's attention should be drawn to.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*