### PR TITLE
Communicate task completion to Scheduler interface. Add two schedulers

### DIFF
--- a/opendc-compute/opendc-compute-api/src/main/kotlin/org/opendc/compute/api/Task.kt
+++ b/opendc-compute/opendc-compute-api/src/main/kotlin/org/opendc/compute/api/Task.kt
@@ -49,6 +49,11 @@ public interface Task : Resource {
     public val launchedAt: Instant?
 
     /**
+     * Time the task was skipped by the scheduler because no host with enough resources was available.
+     */
+    public var timesSkipped: Int
+
+    /**
      * Request the task to be started.
      */
     public fun start()

--- a/opendc-compute/opendc-compute-service/src/main/java/org/opendc/compute/service/HostView.java
+++ b/opendc-compute/opendc-compute-service/src/main/java/org/opendc/compute/service/HostView.java
@@ -33,6 +33,10 @@ public class HostView {
     long availableMemory;
     int provisionedCores;
 
+    // Additional metadata to be used by scheduler
+    public int priorityIndex = -1;
+    public int listIndex = -1;
+
     /**
      * Construct a {@link HostView} instance.
      *

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/ComputeScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/ComputeScheduler.kt
@@ -41,10 +41,17 @@ public interface ComputeScheduler {
     public fun removeHost(host: HostView)
 
     /**
-     * Select a host for the specified [task].
+     * Select a host for the specified [iter].
+     * We implicity assume that the task has been scheduled onto the host.
      *
-     * @param task The server to select a host for.
+     * @param iter The server to select a host for.
      * @return The host to schedule the server on or `null` if no server is available.
      */
-    public fun select(task: Task): HostView?
+    public fun select(iter: MutableIterator<Task>): HostView?
+
+    /**
+     * Inform the scheduler that a task has been removed from the host.
+     * Could be due to completion or failure.
+     */
+    public fun removeTask(task: Task, hv: HostView)
 }

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/ComputeScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/ComputeScheduler.kt
@@ -50,8 +50,11 @@ public interface ComputeScheduler {
     public fun select(iter: MutableIterator<Task>): HostView?
 
     /**
-     * Inform the scheduler that a task has been removed from the host.
+     * Inform the scheduler that a [task] has been removed from the [host].
      * Could be due to completion or failure.
      */
-    public fun removeTask(task: Task, hv: HostView)
+    public fun removeTask(
+        task: Task,
+        host: HostView,
+    )
 }

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/FilterScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/FilterScheduler.kt
@@ -23,7 +23,6 @@
 package org.opendc.compute.service.scheduler
 
 import org.opendc.compute.api.Task
-import org.opendc.compute.service.ComputeService
 import org.opendc.compute.service.HostView
 import org.opendc.compute.service.scheduler.filters.HostFilter
 import org.opendc.compute.service.scheduler.weights.HostWeigher
@@ -111,7 +110,10 @@ public class FilterScheduler(
         }
     }
 
-    override fun removeTask(task: Task, hv: HostView) {
+    override fun removeTask(
+        task: Task,
+        host: HostView,
+    ) {
         TODO("Not yet implemented")
     }
 }

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/FilterScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/FilterScheduler.kt
@@ -23,6 +23,7 @@
 package org.opendc.compute.service.scheduler
 
 import org.opendc.compute.api.Task
+import org.opendc.compute.service.ComputeService
 import org.opendc.compute.service.HostView
 import org.opendc.compute.service.scheduler.filters.HostFilter
 import org.opendc.compute.service.scheduler.weights.HostWeigher
@@ -65,7 +66,8 @@ public class FilterScheduler(
         hosts.remove(host)
     }
 
-    override fun select(task: Task): HostView? {
+    override fun select(iter: MutableIterator<Task>): HostView? {
+        val task = iter.next()
         val hosts = hosts
         val filteredHosts = hosts.filter { host -> filters.all { filter -> filter.test(host, task) } }
 
@@ -107,5 +109,9 @@ public class FilterScheduler(
             1 -> subset[0]
             else -> subset[random.nextInt(maxSize)]
         }
+    }
+
+    override fun removeTask(task: Task, hv: HostView) {
+        TODO("Not yet implemented")
     }
 }

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/MemorizingScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/MemorizingScheduler.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2024 AtLarge Research
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.opendc.compute.service.scheduler
 
 import org.opendc.compute.api.Task
@@ -9,9 +31,8 @@ import java.util.random.RandomGenerator
 public class MemorizingScheduler(
     private val filters: List<HostFilter>,
     private val random: RandomGenerator = SplittableRandom(0),
-    private val maxTimesSkipped: Int = 7
-): ComputeScheduler {
-
+    private val maxTimesSkipped: Int = 7,
+) : ComputeScheduler {
     // We assume that there will be max 200 tasks per host.
     // The index of a host list is the number of tasks on that host.
     private val hostsQueue = List(200, { mutableListOf<HostView>() })
@@ -34,7 +55,7 @@ public class MemorizingScheduler(
         if (listIdx == chosenList.size - 1) {
             chosenList.removeLast()
             if (listIdx == minAvailableHost) {
-                for (i in minAvailableHost+1 .. hostsQueue.lastIndex) {
+                for (i in minAvailableHost + 1..hostsQueue.lastIndex) {
                     if (hostsQueue[i].size > 0) {
                         minAvailableHost = i
                         break
@@ -69,8 +90,8 @@ public class MemorizingScheduler(
                 // Don't skip over it. Wait till a suitable host becomes available
                 val q = hostsQueue[minAvailableHost]
                 for (h in q) {
-                    val satisfied = filters.all { filter -> filter.test(h, task) }
-                    if (satisfied) {
+                    val sfed = filters.all { filter -> filter.test(h, task) }
+                    if (sfed) {
                         chosenHost = h
                         taskFound = true
                         break
@@ -102,9 +123,9 @@ public class MemorizingScheduler(
         return chosenHost
     }
 
-    override fun removeTask(task: Task, hv: HostView) {
-        val priorityIdx = hv.priorityIndex
-        val listIdx = hv.listIndex
+    override fun removeTask(task: Task, host: HostView) {
+        val priorityIdx = host.priorityIndex
+        val listIdx = host.listIndex
         val chosenList = hostsQueue[priorityIdx]
         val nextList = hostsQueue[priorityIdx - 1]
 
@@ -118,8 +139,8 @@ public class MemorizingScheduler(
             chosenList[listIdx] = lastItem
             lastItem.listIndex = listIdx
         }
-        nextList.add(hv)
-        hv.priorityIndex = priorityIdx - 1
-        hv.listIndex = nextList.size - 1
+        nextList.add(host)
+        host.priorityIndex = priorityIdx - 1
+        host.listIndex = nextList.size - 1
     }
 }

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/MemorizingScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/MemorizingScheduler.kt
@@ -1,0 +1,125 @@
+package org.opendc.compute.service.scheduler
+
+import org.opendc.compute.api.Task
+import org.opendc.compute.service.HostView
+import org.opendc.compute.service.scheduler.filters.HostFilter
+import java.util.SplittableRandom
+import java.util.random.RandomGenerator
+
+public class MemorizingScheduler(
+    private val filters: List<HostFilter>,
+    private val random: RandomGenerator = SplittableRandom(0),
+    private val maxTimesSkipped: Int = 7
+): ComputeScheduler {
+
+    // We assume that there will be max 200 tasks per host.
+    // The index of a host list is the number of tasks on that host.
+    private val hostsQueue = List(200, { mutableListOf<HostView>() })
+    private var minAvailableHost = 0
+    private var numHosts = 0
+
+    override fun addHost(host: HostView) {
+        val zeroQueue = hostsQueue[0]
+        zeroQueue.add(host)
+        host.listIndex = zeroQueue.size - 1
+        numHosts++
+        minAvailableHost = 0
+    }
+
+    override fun removeHost(host: HostView) {
+        val priorityIdx = host.priorityIndex
+        val listIdx = host.listIndex
+        val chosenList = hostsQueue[priorityIdx]
+
+        if (listIdx == chosenList.size - 1) {
+            chosenList.removeLast()
+            if (listIdx == minAvailableHost) {
+                for (i in minAvailableHost+1 .. hostsQueue.lastIndex) {
+                    if (hostsQueue[i].size > 0) {
+                        minAvailableHost = i
+                        break
+                    }
+                }
+            }
+        } else {
+            val lastItem = chosenList.removeLast()
+            chosenList[listIdx] = lastItem
+            lastItem.listIndex = listIdx
+        }
+        numHosts--
+    }
+
+    override fun select(iter: MutableIterator<Task>): HostView? {
+        if (numHosts == 0) {
+            return null
+        }
+
+        val chosenList = hostsQueue[minAvailableHost]
+        val nextList = hostsQueue[minAvailableHost + 1]
+        var chosenHost = chosenList.elementAt(random.nextInt(chosenList.size))
+
+        var taskFound = false
+        for (task in iter) {
+            val satisfied = filters.all { filter -> filter.test(chosenHost, task) }
+            if (satisfied) {
+                iter.remove()
+                taskFound = true
+                break
+            } else if (task.timesSkipped >= maxTimesSkipped) {
+                // Don't skip over it. Wait till a suitable host becomes available
+                val q = hostsQueue[minAvailableHost]
+                for (h in q) {
+                    val satisfied = filters.all { filter -> filter.test(h, task) }
+                    if (satisfied) {
+                        chosenHost = h
+                        taskFound = true
+                        break
+                    }
+                }
+                if (!taskFound) {
+                    return null
+                }
+            } else {
+                task.timesSkipped++
+            }
+        }
+        if (!taskFound) return null // No task found that fits in the host
+
+        val listIdx = chosenHost.listIndex
+
+        if (listIdx == chosenList.size - 1) {
+            chosenList.removeLast()
+            if (chosenList.isEmpty()) minAvailableHost++
+        } else {
+            val lastItem = chosenList.removeLast()
+            chosenList[listIdx] = lastItem
+            lastItem.listIndex = listIdx
+        }
+        nextList.add(chosenHost)
+        chosenHost.priorityIndex = minAvailableHost + 1
+        chosenHost.listIndex = nextList.size - 1
+
+        return chosenHost
+    }
+
+    override fun removeTask(task: Task, hv: HostView) {
+        val priorityIdx = hv.priorityIndex
+        val listIdx = hv.listIndex
+        val chosenList = hostsQueue[priorityIdx]
+        val nextList = hostsQueue[priorityIdx - 1]
+
+        if (listIdx == chosenList.size - 1) {
+            chosenList.removeLast()
+            if (listIdx == minAvailableHost) {
+                minAvailableHost--
+            }
+        } else {
+            val lastItem = chosenList.removeLast()
+            chosenList[listIdx] = lastItem
+            lastItem.listIndex = listIdx
+        }
+        nextList.add(hv)
+        hv.priorityIndex = priorityIdx - 1
+        hv.listIndex = nextList.size - 1
+    }
+}

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/ReplayScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/ReplayScheduler.kt
@@ -48,7 +48,8 @@ public class ReplayScheduler(private val vmPlacements: Map<String, String>) : Co
         hosts.remove(host)
     }
 
-    override fun select(task: Task): HostView? {
+    override fun select(iter: MutableIterator<Task>): HostView? {
+        val task = iter.next()
         val clusterName =
             vmPlacements[task.name]
                 ?: throw IllegalStateException("Could not find placement data in VM placement file for VM ${task.name}")
@@ -61,5 +62,9 @@ public class ReplayScheduler(private val vmPlacements: Map<String, String>) : Co
 
         return machinesInCluster.maxByOrNull { it.availableMemory }
             ?: throw IllegalStateException("Cloud not find any machine and could not randomly assign")
+    }
+
+    override fun removeTask(task: Task, hv: HostView) {
+        TODO("Not yet implemented")
     }
 }

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/ReplayScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/ReplayScheduler.kt
@@ -64,7 +64,7 @@ public class ReplayScheduler(private val vmPlacements: Map<String, String>) : Co
             ?: throw IllegalStateException("Cloud not find any machine and could not randomly assign")
     }
 
-    override fun removeTask(task: Task, hv: HostView) {
+    override fun removeTask(task: Task, host: HostView) {
         TODO("Not yet implemented")
     }
 }

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/TwoChoiceScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/TwoChoiceScheduler.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2024 AtLarge Research
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.opendc.compute.service.scheduler
 
 import org.opendc.compute.api.Task
@@ -56,7 +78,7 @@ public class TwoChoiceScheduler(
         return chosenHost
     }
 
-    override fun removeTask(task: Task, hv: HostView) {
+    override fun removeTask(task: Task, host: HostView) {
         // All necessary bookkeeping is already handled by ComputeService
         // ComputeService increments/decrements the number of instances on a host
     }

--- a/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/TwoChoiceScheduler.kt
+++ b/opendc-compute/opendc-compute-service/src/main/kotlin/org/opendc/compute/service/scheduler/TwoChoiceScheduler.kt
@@ -1,0 +1,63 @@
+package org.opendc.compute.service.scheduler
+
+import org.opendc.compute.api.Task
+import org.opendc.compute.service.HostView
+import org.opendc.compute.service.scheduler.filters.HostFilter
+import java.util.SplittableRandom
+import java.util.random.RandomGenerator
+
+public class TwoChoiceScheduler(
+    private val filters: List<HostFilter>,
+    private val random: RandomGenerator = SplittableRandom(0),
+): ComputeScheduler {
+
+    private val hostsList = mutableListOf<HostView>()
+    private var numHosts = 0
+
+    override fun addHost(host: HostView) {
+        hostsList.add(host)
+        host.listIndex = hostsList.size
+        numHosts++
+    }
+
+    override fun removeHost(host: HostView) {
+        val listIdx = host.listIndex
+
+        if (listIdx == hostsList.size - 1) {
+            hostsList.removeLast()
+        } else {
+            val lastItem = hostsList.removeLast()
+            hostsList[listIdx] = lastItem
+            lastItem.listIndex = listIdx
+        }
+        numHosts--
+    }
+
+    override fun select(iter: MutableIterator<Task>): HostView? {
+        if (numHosts == 0) {
+            return null
+        }
+
+        val chosen1 = hostsList.elementAt(random.nextInt(hostsList.size))
+        val chosen2 = hostsList.elementAt(random.nextInt(hostsList.size))
+        val chosenHost = minOf(chosen1, chosen2, { a, b -> a.instanceCount - b.instanceCount })
+
+        var taskFound = false
+        for (task in iter) {
+            val satisfied = filters.all { filter -> filter.test(chosenHost, task) }
+            if (satisfied) {
+                iter.remove()
+                taskFound = true
+                break
+            }
+        }
+        if (!taskFound) return null // No task found that fits in the host
+
+        return chosenHost
+    }
+
+    override fun removeTask(task: Task, hv: HostView) {
+        // All necessary bookkeeping is already handled by ComputeService
+        // ComputeService increments/decrements the number of instances on a host
+    }
+}

--- a/opendc-compute/opendc-compute-service/src/test/kotlin/org/opendc/compute/service/ServiceTaskTest.kt
+++ b/opendc-compute/opendc-compute-service/src/test/kotlin/org/opendc/compute/service/ServiceTaskTest.kt
@@ -23,6 +23,7 @@
 package org.opendc.compute.service
 
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.yield
@@ -133,7 +134,7 @@ class ServiceTaskTest {
                     mutableMapOf<String, Any>(),
                 )
 
-            every { service.schedule(any()) } answers { ComputeService.SchedulingRequest(it.invocation.args[0] as ServiceTask, 0) }
+            every { service.schedule(any()) } answers {  }
 
             server.start()
 
@@ -231,14 +232,13 @@ class ServiceTaskTest {
                     mutableMapOf(),
                     mutableMapOf<String, Any>(),
                 )
-            val request = ComputeService.SchedulingRequest(server, 0)
 
-            every { service.schedule(any()) } returns request
+            justRun { service.schedule(any()) }
 
             server.start()
             server.stop()
 
-            assertTrue(request.isCancelled)
+            assertTrue(server.isCancelled)
             assertEquals(TaskState.TERMINATED, server.state)
         }
 
@@ -334,14 +334,13 @@ class ServiceTaskTest {
                     mutableMapOf(),
                     mutableMapOf<String, Any>(),
                 )
-            val request = ComputeService.SchedulingRequest(server, 0)
 
-            every { service.schedule(any()) } returns request
+            justRun { service.schedule(any()) }
 
             server.start()
             server.delete()
 
-            assertTrue(request.isCancelled)
+            assertTrue(server.isCancelled)
             assertEquals(TaskState.DELETED, server.state)
             verify { service.delete(server) }
         }

--- a/opendc-compute/opendc-compute-service/src/test/kotlin/org/opendc/compute/service/scheduler/FilterSchedulerTest.kt
+++ b/opendc-compute/opendc-compute-service/src/test/kotlin/org/opendc/compute/service/scheduler/FilterSchedulerTest.kt
@@ -82,7 +82,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertNull(scheduler.select(task))
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -108,8 +108,8 @@ internal class FilterSchedulerTest {
 
         // Make sure we get the first host both times
         assertAll(
-            { assertEquals(hostA, scheduler.select(task)) },
-            { assertEquals(hostA, scheduler.select(task)) },
+            { assertEquals(hostA, scheduler.select(mutableListOf(task).iterator())) },
+            { assertEquals(hostA, scheduler.select(mutableListOf(task).iterator())) },
         )
     }
 
@@ -138,8 +138,8 @@ internal class FilterSchedulerTest {
 
         // Make sure we get the first host both times
         assertAll(
-            { assertEquals(hostB, scheduler.select(task)) },
-            { assertEquals(hostA, scheduler.select(task)) },
+            { assertEquals(hostB, scheduler.select(mutableListOf(task).iterator())) },
+            { assertEquals(hostA, scheduler.select(mutableListOf(task).iterator())) },
         )
     }
 
@@ -160,7 +160,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertNull(scheduler.select(task))
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -180,7 +180,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertEquals(host, scheduler.select(task))
+        assertEquals(host, scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -208,7 +208,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertEquals(hostB, scheduler.select(task))
+        assertEquals(hostB, scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -230,7 +230,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 2300
 
-        assertNull(scheduler.select(task))
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -258,7 +258,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertEquals(hostB, scheduler.select(task))
+        assertEquals(hostB, scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -280,7 +280,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 8
         every { task.flavor.memorySize } returns 1024
 
-        assertNull(scheduler.select(task))
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
     }
 
 // TODO: fix when schedulers are reworked
@@ -310,7 +310,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.memorySize } returns 1024
         every { task.flavor.meta } returns mapOf("cpu-capacity" to 2 * 3200.0)
 
-        assertEquals(hostB, scheduler.select(task))
+        assertEquals(hostB, scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -338,7 +338,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertEquals(hostB, scheduler.select(task))
+        assertEquals(hostB, scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -374,11 +374,11 @@ internal class FilterSchedulerTest {
         every { taskB.flavor.memorySize } returns 1024
         every { taskB.meta } returns emptyMap()
 
-        assertEquals(hostA, scheduler.select(taskB))
+        assertEquals(hostA, scheduler.select(mutableListOf(taskB).iterator()))
 
         every { taskB.meta } returns mapOf("scheduler_hint:same_host" to setOf(taskA.uid))
 
-        assertEquals(hostB, scheduler.select(taskB))
+        assertEquals(hostB, scheduler.select(mutableListOf(taskB).iterator()))
     }
 
     @Test
@@ -414,11 +414,11 @@ internal class FilterSchedulerTest {
         every { taskB.flavor.memorySize } returns 1024
         every { taskB.meta } returns emptyMap()
 
-        assertEquals(hostA, scheduler.select(taskB))
+        assertEquals(hostA, scheduler.select(mutableListOf(taskB).iterator()))
 
         every { taskB.meta } returns mapOf("scheduler_hint:different_host" to setOf(taskA.uid))
 
-        assertEquals(hostB, scheduler.select(taskB))
+        assertEquals(hostB, scheduler.select(mutableListOf(taskB).iterator()))
     }
 
     @Test
@@ -446,7 +446,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertEquals(hostA, scheduler.select(task))
+        assertEquals(hostA, scheduler.select(mutableListOf(task).iterator()))
     }
 
     // TODO: fix test when updating schedulers
@@ -475,7 +475,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertEquals(hostB, scheduler.select(task))
+        assertEquals(hostB, scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -503,7 +503,7 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertEquals(hostB, scheduler.select(task))
+        assertEquals(hostB, scheduler.select(mutableListOf(task).iterator()))
     }
 
     @Test
@@ -531,6 +531,6 @@ internal class FilterSchedulerTest {
         every { task.flavor.coreCount } returns 2
         every { task.flavor.memorySize } returns 1024
 
-        assertEquals(hostB, scheduler.select(task))
+        assertEquals(hostB, scheduler.select(mutableListOf(task).iterator()))
     }
 }

--- a/opendc-compute/opendc-compute-service/src/test/kotlin/org/opendc/compute/service/scheduler/MemorizingSchedulerTest.kt
+++ b/opendc-compute/opendc-compute-service/src/test/kotlin/org/opendc/compute/service/scheduler/MemorizingSchedulerTest.kt
@@ -1,0 +1,126 @@
+package org.opendc.compute.service.scheduler
+
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.opendc.compute.api.Task
+import org.opendc.compute.service.HostView
+import org.opendc.compute.service.driver.HostModel
+import org.opendc.compute.service.driver.HostState
+import org.opendc.compute.service.scheduler.filters.RamFilter
+import java.util.Random
+import java.util.random.RandomGenerator
+
+internal class MemorizingSchedulerTest {
+    @Test
+    fun testNoHosts() {
+        val scheduler =
+            MemorizingScheduler(
+                filters = emptyList(),
+            )
+
+        val task = mockk<Task>()
+        every { task.flavor.coreCount } returns 2
+        every { task.flavor.memorySize } returns 1024
+
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
+    }
+
+    @Test
+    fun testNoFiltersAndSchedulersRandom() {
+        val scheduler =
+            MemorizingScheduler(
+                filters = emptyList(),
+                random = Random(1),
+            )
+
+        val hostA = mockk<HostView>()
+        every { hostA.host.state } returns HostState.DOWN
+
+        val hostB = mockk<HostView>()
+        every { hostB.host.state } returns HostState.UP
+
+        scheduler.addHost(hostA)
+        scheduler.addHost(hostB)
+
+        val task = mockk<Task>()
+        every { task.flavor.coreCount } returns 2
+        every { task.flavor.memorySize } returns 1024
+
+        // Make sure we get the first host both times
+        assertAll(
+            { assertEquals(hostB, scheduler.select(mutableListOf(task).iterator())) },
+            { assertEquals(hostA, scheduler.select(mutableListOf(task).iterator())) },
+        )
+    }
+
+    @Test
+    fun testRamFilter() {
+        // Make Random with predictable order of numbers to test max skipped logic
+        val r = mockk<RandomGenerator>()
+        val scheduler =
+            MemorizingScheduler(
+                filters = listOf(RamFilter(1.0)),
+                random = r,
+                maxTimesSkipped = 3
+            )
+
+        every { r.nextInt(any()) } returns 0
+
+        val hostA = mockk<HostView>()
+        every { hostA.host.state } returns HostState.UP
+        every { hostA.host.model } returns HostModel(4 * 2600.0, 1, 4, 2048)
+        every { hostA.availableMemory } returns 512
+
+        val hostB = mockk<HostView>()
+        every { hostB.host.state } returns HostState.UP
+        every { hostB.host.model } returns HostModel(4 * 2600.0, 1, 4, 2048)
+        every { hostB.availableMemory } returns 2048
+
+        scheduler.addHost(hostA)
+        scheduler.addHost(hostB)
+
+        val task = mockk<Task>()
+        every { task.flavor.coreCount } returns 2
+        every { task.flavor.memorySize } returns 1024
+        val skipped = slot<Int>()
+        justRun { task.setProperty("timesSkipped") value capture(skipped)  }
+        every { task.getProperty("timesSkipped") } answers { skipped.captured }
+        task.timesSkipped = 0
+
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
+        assertEquals(hostB, scheduler.select(mutableListOf(task).iterator()))
+    }
+
+    @Test
+    fun testRamFilterOvercommit() {
+        val scheduler =
+            MemorizingScheduler(
+                filters = listOf(RamFilter(1.5))
+            )
+
+        val host = mockk<HostView>()
+        every { host.host.state } returns HostState.UP
+        every { host.host.model } returns HostModel(4 * 2600.0, 1, 4, 2048)
+        every { host.availableMemory } returns 2048
+
+        scheduler.addHost(host)
+
+        val task = mockk<Task>()
+        every { task.flavor.coreCount } returns 2
+        every { task.flavor.memorySize } returns 2300
+        val skipped = slot<Int>()
+        justRun { task.setProperty("timesSkipped") value capture(skipped)  }
+        every { task.getProperty("timesSkipped") } answers { skipped.captured }
+        task.timesSkipped = 0
+
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
+    }
+}

--- a/opendc-compute/opendc-compute-service/src/test/kotlin/org/opendc/compute/service/scheduler/TwoChoiceSchedulerTest.kt
+++ b/opendc-compute/opendc-compute-service/src/test/kotlin/org/opendc/compute/service/scheduler/TwoChoiceSchedulerTest.kt
@@ -1,0 +1,88 @@
+package org.opendc.compute.service.scheduler
+
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.opendc.compute.api.Task
+import org.opendc.compute.service.HostView
+import org.opendc.compute.service.driver.Host
+import org.opendc.compute.service.driver.HostModel
+import org.opendc.compute.service.driver.HostState
+import org.opendc.compute.service.scheduler.filters.RamFilter
+import java.util.Random
+import java.util.random.RandomGenerator
+
+internal class TwoChoiceSchedulerTest {
+    @Test
+    fun testNoHosts() {
+        val scheduler =
+            TwoChoiceScheduler(
+                filters = emptyList(),
+            )
+
+        val task = mockk<Task>()
+        every { task.flavor.coreCount } returns 2
+        every { task.flavor.memorySize } returns 1024
+
+        assertNull(scheduler.select(mutableListOf(task).iterator()))
+    }
+
+    @Test
+    fun testNoFiltersAndSchedulersRandom() {
+        val scheduler =
+            TwoChoiceScheduler(
+                filters = emptyList(),
+                random = Random(1),
+            )
+
+        val hostSource = mockk<Host>()
+        every { hostSource.getModel().memoryCapacity() } returns 1
+
+        val hostA = HostView(hostSource)
+        val hostB = HostView(hostSource)
+
+        scheduler.addHost(hostA)
+        scheduler.addHost(hostB)
+
+        val task = mockk<Task>()
+        every { task.flavor.coreCount } returns 2
+        every { task.flavor.memorySize } returns 1024
+
+        // Make sure we get the first host both times
+        assertAll(
+            { assertEquals(hostB, scheduler.select(mutableListOf(task).iterator())) },
+            { assertEquals(hostA, scheduler.select(mutableListOf(task).iterator())) },
+        )
+    }
+
+    @Test
+    fun testRamFilter() {
+        val scheduler =
+            TwoChoiceScheduler(
+                filters = listOf(RamFilter(1.0)),
+                random = Random(1),
+            )
+
+        val hostSourceA = mockk<Host>()
+        every { hostSourceA.getModel() } returns HostModel(4 * 2600.0, 1, 4, 512)
+        val hostSourceB = mockk<Host>()
+        every { hostSourceB.getModel() } returns HostModel(4 * 2600.0, 1, 4, 2048)
+
+        val hostA = HostView(hostSourceA)
+        val hostB = HostView(hostSourceB)
+
+        scheduler.addHost(hostA)
+        scheduler.addHost(hostB)
+
+        val task = mockk<Task>()
+        every { task.flavor.coreCount } returns 2
+        every { task.flavor.memorySize } returns 1024
+
+        assertEquals(hostB, scheduler.select(mutableListOf(task).iterator()))
+    }
+}


### PR DESCRIPTION
## Summary

Currently, the scheduling cycle for each task scans all available hosts. This is necessary because the scheduler doesn't know each host's capacity.
The scheduler can track each host's capacity if it knowns when each task starts and ends. I added an additional function to the scheduler interface to track task ends. The scheduler now also receives multiple tasks to schedule at a time, rather than just one.

Using the interface, I implement two new schedulers: 1) A memorizing one, which uses a calender priority queue to track which host is least occupied. 2) A power of two random choices scheduler.

## Implementation Notes :hammer_and_pick:

* The scheduler now accept multiple tasks with a `select(iter: MutableIterator<Task>): HostView?` interface instead of `select(task: Task): HostView?`. This allows the scheduler to pick a task which is not at the top of the queue.
* The Task interface now has a field, timeSkipped, which keeps track of how many time the task was skipped when it was at the head of the queue. If a task has been skipped a specified maximum number of times, no other task is scheduled until this one is.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*