### PR TITLE
Updated export model

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/ComputeMonitorProvisioningStep.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/ComputeMonitorProvisioningStep.kt
@@ -53,6 +53,6 @@ public class ComputeMonitorProvisioningStep(
                 startTime,
                 carbonTrace,
             )
-        return AutoCloseable { metricReader.close() }
+        return metricReader
     }
 }

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/Provisioner.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/Provisioner.kt
@@ -24,6 +24,7 @@ package org.opendc.compute.simulator.provisioner
 
 import org.opendc.common.Dispatcher
 import org.opendc.compute.simulator.ServiceRegistry
+import org.opendc.compute.simulator.telemetry.ComputeMetricReader
 import java.util.ArrayDeque
 import java.util.SplittableRandom
 
@@ -60,6 +61,16 @@ public class Provisioner(dispatcher: Dispatcher, seed: Long) : AutoCloseable {
      */
     public val registry: ServiceRegistry
         get() = context.registry
+
+    public fun getMonitor(): ComputeMetricReader? {
+        for (element in stack) {
+            if (element is ComputeMetricReader) {
+                return element
+            }
+        }
+
+        return null
+    }
 
     /**
      * Run a single [ProvisioningStep] for this environment.

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/ComputeMetricReader.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/ComputeMetricReader.kt
@@ -108,7 +108,7 @@ public class ComputeMetricReader(
             }
         }
 
-    private fun loggState() {
+    public fun loggState() {
         loggCounter++
         try {
             val now = this.clock.instant()

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
@@ -109,7 +109,11 @@ public fun runScenario(
             val startTime = Duration.ofMillis(tasks.minOf { it.submissionTime }.toEpochMilli())
             addExportModel(provisioner, serviceDomain, scenario, seed, startTime, carbonTrace, scenario.id)
 
+            val monitor = provisioner.getMonitor()
+
             val service = provisioner.registry.resolve(serviceDomain, ComputeService::class.java)!!
+            service.setMetricReader(monitor)
+            service.setTasksExpected(tasks.size)
             service.replay(
                 timeSource,
                 tasks,


### PR DESCRIPTION
## Summary

Made a few small changes that force the simulation to end at the same timestamp regardless of the exportfrequency. 

## Implementation Notes :hammer_and_pick:

ComputeService now forces ComputeMetricReader to export information when all tasks in the workload trace have been completed.

After this final export, all tasks are deleted and the simulation ends.

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*