### PR TITLE
Small update to trace-based failure models

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/models/TraceBasedFailureModel.kt
+++ b/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/models/TraceBasedFailureModel.kt
@@ -118,7 +118,7 @@ public class TraceBasedFailureModel(
             }
 
             val startIndex: Int = (entries.size * startPoint).toInt()
-            return entries.subList(startIndex, entries.size) + entries.subList(startIndex, entries.size)
+            return entries.subList(startIndex, entries.size) + entries.subList(0, startIndex)
         } catch (e: Exception) {
             e.printStackTrace()
             throw e

--- a/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/models/TraceBasedFailureModel.kt
+++ b/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/models/TraceBasedFailureModel.kt
@@ -33,7 +33,6 @@ import java.io.File
 import java.time.InstantSource
 import java.util.random.RandomGenerator
 import kotlin.coroutines.CoroutineContext
-import kotlin.math.floor
 import kotlin.time.times
 
 /**
@@ -95,7 +94,10 @@ public class TraceBasedFailureModel(
      *
      * @param pathToFile
      */
-    private fun loadTrace(pathToFile: String, startPoint: Double): List<Failure> {
+    private fun loadTrace(
+        pathToFile: String,
+        startPoint: Double,
+    ): List<Failure> {
         val trace = Trace.open(File(pathToFile), "failure")
 
         val reader = checkNotNull(trace.getTable(TABLE_FAILURES)).newReader()

--- a/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/models/TraceBasedFailureModel.kt
+++ b/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/models/TraceBasedFailureModel.kt
@@ -33,6 +33,8 @@ import java.io.File
 import java.time.InstantSource
 import java.util.random.RandomGenerator
 import kotlin.coroutines.CoroutineContext
+import kotlin.math.floor
+import kotlin.time.times
 
 /**
  * A definition of a Failure
@@ -71,9 +73,10 @@ public class TraceBasedFailureModel(
     service: ComputeService,
     random: RandomGenerator,
     pathToTrace: String,
-    private val repeat: Boolean = false,
+    startPoint: Double,
+    private val repeat: Boolean = true,
 ) : FailureModel(context, clock, service, random) {
-    private val failureList = loadTrace(pathToTrace)
+    private val failureList = loadTrace(pathToTrace, startPoint)
 
     override suspend fun runInjector() {
         do {
@@ -92,7 +95,7 @@ public class TraceBasedFailureModel(
      *
      * @param pathToFile
      */
-    private fun loadTrace(pathToFile: String): List<Failure> {
+    private fun loadTrace(pathToFile: String, startPoint: Double): List<Failure> {
         val trace = Trace.open(File(pathToFile), "failure")
 
         val reader = checkNotNull(trace.getTable(TABLE_FAILURES)).newReader()
@@ -112,7 +115,8 @@ public class TraceBasedFailureModel(
                 entries.add(Failure(failureStartTime, failureDuration, failureIntensity))
             }
 
-            return entries
+            val startIndex: Int = (entries.size * startPoint).toInt()
+            return entries.subList(startIndex, entries.size) + entries.subList(startIndex, entries.size)
         } catch (e: Exception) {
             e.printStackTrace()
             throw e

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/FailureModelSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/FailureModelSpec.kt
@@ -81,7 +81,7 @@ public sealed interface FailureModelSpec {
 @Serializable
 @SerialName("no")
 public data class NoFailureModel(
-    override var name: String = "no failure model"
+    override var name: String = "no failure model",
 ) : FailureModelSpec
 
 /**
@@ -94,7 +94,7 @@ public data class NoFailureModel(
 public data class TraceBasedFailureModelSpec(
     public val pathToFile: String,
     public val startPoint: Double = 0.0,
-    public val repeat: Boolean = true
+    public val repeat: Boolean = true,
 ) : FailureModelSpec {
     override var name: String = File(pathToFile).nameWithoutExtension
 

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/FailureModelSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/FailureModelSpec.kt
@@ -78,6 +78,12 @@ public sealed interface FailureModelSpec {
     public var name: String
 }
 
+@Serializable
+@SerialName("no")
+public data class NoFailureModel(
+    override var name: String = "no failure model"
+) : FailureModelSpec
+
 /**
  * A failure model spec for failure models based on a failure trace.
  *
@@ -87,11 +93,15 @@ public sealed interface FailureModelSpec {
 @SerialName("trace-based")
 public data class TraceBasedFailureModelSpec(
     public val pathToFile: String,
+    public val startPoint: Double = 0.0,
+    public val repeat: Boolean = true
 ) : FailureModelSpec {
     override var name: String = File(pathToFile).nameWithoutExtension
 
     init {
         require(File(pathToFile).exists()) { "Path to file $pathToFile does not exist" }
+        require(startPoint < 1.0) { "Starting point must be smaller than 1.0" }
+        require(startPoint >= 0.0) { "Starting point must be equal or larger than 0.0" }
     }
 }
 
@@ -267,7 +277,7 @@ public fun createFailureModel(
     random: java.util.random.RandomGenerator,
     failureModel: TraceBasedFailureModelSpec,
 ): FailureModel {
-    return TraceBasedFailureModel(context, clock, service, random, failureModel.pathToFile)
+    return TraceBasedFailureModel(context, clock, service, random, failureModel.pathToFile, failureModel.startPoint, failureModel.repeat)
 }
 
 /**

--- a/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ScenarioIntegrationTest.kt
+++ b/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ScenarioIntegrationTest.kt
@@ -135,8 +135,11 @@ class ScenarioIntegrationTest {
             val workload = createTestWorkload("single_task", 1.0, seed)
             val topology = createTopology("single.json")
             val monitor = monitor
-            val failureModelSpec = TraceBasedFailureModelSpec(
-                "src/test/resources/failureTraces/single_failure.parquet", repeat=false)
+            val failureModelSpec =
+                TraceBasedFailureModelSpec(
+                    "src/test/resources/failureTraces/single_failure.parquet",
+                    repeat = false,
+                )
 
             Provisioner(dispatcher, seed).use { provisioner ->
                 provisioner.runSteps(

--- a/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ScenarioIntegrationTest.kt
+++ b/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ScenarioIntegrationTest.kt
@@ -135,7 +135,8 @@ class ScenarioIntegrationTest {
             val workload = createTestWorkload("single_task", 1.0, seed)
             val topology = createTopology("single.json")
             val monitor = monitor
-            val failureModelSpec = TraceBasedFailureModelSpec("src/test/resources/failureTraces/single_failure.parquet")
+            val failureModelSpec = TraceBasedFailureModelSpec(
+                "src/test/resources/failureTraces/single_failure.parquet", repeat=false)
 
             Provisioner(dispatcher, seed).use { provisioner ->
                 provisioner.runSteps(
@@ -145,6 +146,8 @@ class ScenarioIntegrationTest {
                 )
 
                 val service = provisioner.registry.resolve("compute.opendc.org", ComputeService::class.java)!!
+                service.setTasksExpected(workload.size)
+
                 service.replay(timeSource, workload, failureModelSpec = failureModelSpec, seed = seed)
             }
 


### PR DESCRIPTION
## Summary

Added startPoint to TraceBasedFailureModel.kt, this decides where in the trace, the model should start. 

Added repeat to TraceBasedFailureModel.kt. This decides if the trace should be repeated when finished.

Added a no failure model to the FailiureModelSpecs. The user can now add a FailureModel with type "no". This will do nothing, but is needed if you want to create an experiment that should run simulations with and without failures.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*