### PR TITLE
Removed IndexOf function from Multiplexer

### DIFF
--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/Multiplexer.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/Multiplexer.java
@@ -127,6 +127,8 @@ public class Multiplexer extends FlowNode implements FlowSupplier, FlowConsumer 
      */
     @Override
     public void addConsumerEdge(FlowEdge consumerEdge) {
+        consumerEdge.setConsumerIndex(this.consumerEdges.size());
+
         this.consumerEdges.add(consumerEdge);
         this.demands.add(0.0);
         this.supplies.add(0.0);
@@ -145,7 +147,7 @@ public class Multiplexer extends FlowNode implements FlowSupplier, FlowConsumer 
 
     @Override
     public void removeConsumerEdge(FlowEdge consumerEdge) {
-        int idx = this.consumerEdges.indexOf(consumerEdge);
+        int idx = consumerEdge.getConsumerIndex();
 
         if (idx == -1) {
             return;
@@ -156,6 +158,11 @@ public class Multiplexer extends FlowNode implements FlowSupplier, FlowConsumer 
         this.consumerEdges.remove(idx);
         this.demands.remove(idx);
         this.supplies.remove(idx);
+
+        // update the consumer index for all consumerEdges higher than this.
+        for (int i = idx; i < this.consumerEdges.size(); i++) {
+            this.consumerEdges.get(i).setConsumerIndex(i);
+        }
 
         this.invalidate();
     }
@@ -169,7 +176,7 @@ public class Multiplexer extends FlowNode implements FlowSupplier, FlowConsumer 
 
     @Override
     public void handleDemand(FlowEdge consumerEdge, double newDemand) {
-        int idx = consumerEdges.indexOf(consumerEdge);
+        int idx = consumerEdge.getConsumerIndex();
 
         if (idx == -1) {
             System.out.println("Error (Multiplexer): Demand pushed by an unknown consumer");
@@ -201,7 +208,7 @@ public class Multiplexer extends FlowNode implements FlowSupplier, FlowConsumer 
 
     @Override
     public void pushSupply(FlowEdge consumerEdge, double newSupply) {
-        int idx = consumerEdges.indexOf(consumerEdge);
+        int idx = consumerEdge.getConsumerIndex();
 
         if (idx == -1) {
             System.out.println("Error (Multiplexer): pushing supply to an unknown consumer");

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/FlowEdge.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/FlowEdge.java
@@ -32,6 +32,9 @@ public class FlowEdge {
     private FlowConsumer consumer;
     private FlowSupplier supplier;
 
+    private int consumerIndex = -1;
+    private int supplierIndex = -1;
+
     private double demand = 0.0;
     private double supply = 0.0;
 
@@ -84,6 +87,22 @@ public class FlowEdge {
 
     public double getSupply() {
         return this.supply;
+    }
+
+    public int getConsumerIndex() {
+        return consumerIndex;
+    }
+
+    public void setConsumerIndex(int consumerIndex) {
+        this.consumerIndex = consumerIndex;
+    }
+
+    public int getSupplierIndex() {
+        return supplierIndex;
+    }
+
+    public void setSupplierIndex(int supplierIndex) {
+        this.supplierIndex = supplierIndex;
     }
 
     /**


### PR DESCRIPTION
## Summary

Removed the IndexOf function from Multiplexer.java, by adding a consumerIndex variable to FlowEdge.java.
This improves performance significantly. 

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*