### PR TITLE
Small FlowNode bug fix

### DIFF
--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimTraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimTraceWorkload.java
@@ -245,6 +245,9 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
      */
     @Override
     public void removeSupplierEdge(FlowEdge supplierEdge) {
+        if (this.machineEdge == null) {
+            return;
+        }
         this.stopWorkload();
     }
 }

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowNode.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowNode.java
@@ -157,6 +157,11 @@ public abstract class FlowNode {
      * Update the state of the stage.
      */
     public void update(long now) {
+        if (this.nodeState == NodeState.CLOSED) {
+            this.deadline = Long.MAX_VALUE;
+            return;
+        }
+
         this.nodeState = NodeState.UPDATING;
 
         long newDeadline = this.deadline;


### PR DESCRIPTION
## Summary

Solved a small bug that let FlowNodes update while they are in a closed state.
This would lead to OpenDC trying to reach elements that were nulled.

## Implementation Notes :hammer_and_pick:

Added an if-statement

## External Dependencies :four_leaf_clover:

N/A

## Breaking API Changes :warning:

N/A

*Simply specify none (N/A) if not applicable.*