### PR TITLE
Updated the FlowEngine

### DIFF
--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimChainWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimChainWorkload.java
@@ -270,6 +270,10 @@ final class SimChainWorkload extends SimWorkload implements FlowSupplier {
      */
     @Override
     public void removeSupplierEdge(FlowEdge supplierEdge) {
+        if (this.machineEdge == null) {
+            return;
+        }
+
         this.stopWorkload();
     }
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimTraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/SimTraceWorkload.java
@@ -139,6 +139,10 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
 
     @Override
     public void stopWorkload() {
+        if (this.machineEdge == null) {
+            return;
+        }
+
         this.closeNode();
 
         this.machineEdge = null;

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/engine/FlowEngine.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/engine/FlowEngine.java
@@ -37,9 +37,9 @@ import org.opendc.simulator.engine.graph.FlowNode;
  */
 public final class FlowEngine implements Runnable {
     /**
-     * The queue of {@link FlowNode} updates that are scheduled for immediate execution.
+     * The queue of {@link FlowNode} updates that need to be updated in the current cycle.
      */
-    private final FlowNodeQueue queue = new FlowNodeQueue(256);
+    private final FlowCycleQueue cycleQueue = new FlowCycleQueue(256);
 
     /**
      * A priority queue containing the {@link FlowNode} updates to be scheduled in the future.
@@ -112,7 +112,7 @@ public final class FlowEngine implements Runnable {
      * This method should only be invoked while inside an engine cycle.
      */
     public void scheduleImmediateInContext(FlowNode ctx) {
-        queue.add(ctx);
+        cycleQueue.add(ctx);
     }
 
     /**
@@ -147,7 +147,7 @@ public final class FlowEngine implements Runnable {
      * Run all the enqueued actions for the specified timestamp (<code>now</code>).
      */
     private void doRunEngine(long now) {
-        final FlowNodeQueue queue = this.queue;
+        final FlowCycleQueue queue = this.cycleQueue;
         final FlowTimerQueue timerQueue = this.timerQueue;
 
         try {


### PR DESCRIPTION
## Summary

Updated the Flow Engine to not allow nodes to be scheduled multiple times in the queue of nodes that need updates. 

Renamed the FlowNodeQueue to FlowCycleQueue to better explain its function.


A small summary of the requirements (in one/two sentences).

## Implementation Notes :hammer_and_pick:

Added a check for uniqueness when adding a node to the queue.

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*