### PR TITLE
Added sampleFraction and submissionTime to the workloadSpec

### DIFF
--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
@@ -49,10 +49,11 @@ import kotlin.math.roundToLong
  */
 public class ComputeWorkloadLoader(
     private val pathToFile: File,
-    private val checkpointInterval: Long,
-    private val checkpointDuration: Long,
-    private val checkpointIntervalScaling: Double,
-) : WorkloadLoader() {
+    private val subMissionTime: String? = null,
+    private val checkpointInterval: Long = 0L,
+    private val checkpointDuration: Long = 0L,
+    private val checkpointIntervalScaling: Double = 1.0,
+) : WorkloadLoader(subMissionTime) {
     /**
      * The logger for this instance.
      */
@@ -160,25 +161,29 @@ public class ComputeWorkloadLoader(
      * Load the trace at the specified [pathToFile].
      */
     override fun load(): List<Task> {
-        val ref =
-            cache.compute(pathToFile) { key, oldVal ->
-                val inst = oldVal?.get()
-                if (inst == null) {
-//                    val path = baseDir.resolve(key)
+        val trace = Trace.open(pathToFile, "opendc-vm")
+        val fragments = parseFragments(trace)
+        val vms = parseMeta(trace, fragments)
 
-                    logger.info { "Loading trace $key at $pathToFile" }
+        return vms
 
-                    val trace = Trace.open(pathToFile, "opendc-vm")
-                    val fragments = parseFragments(trace)
-                    val vms = parseMeta(trace, fragments)
-
-                    SoftReference(vms)
-                } else {
-                    oldVal
-                }
-            }
-
-        return checkNotNull(ref?.get()) { "Memory pressure" }
+//        val ref =
+//            cache.compute(pathToFile) { key, oldVal ->
+//                val inst = oldVal?.get()
+//                if (inst == null) {
+//                    logger.info { "Loading trace $key at $pathToFile" }
+//
+//                    val trace = Trace.open(pathToFile, "opendc-vm")
+//                    val fragments = parseFragments(trace)
+//                    val vms = parseMeta(trace, fragments)
+//
+//                    SoftReference(vms)
+//                } else {
+//                    oldVal
+//                }
+//            }
+//
+//        return checkNotNull(ref?.get()) { "Memory pressure" }
     }
 
     /**

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
@@ -166,24 +166,6 @@ public class ComputeWorkloadLoader(
         val vms = parseMeta(trace, fragments)
 
         return vms
-
-//        val ref =
-//            cache.compute(pathToFile) { key, oldVal ->
-//                val inst = oldVal?.get()
-//                if (inst == null) {
-//                    logger.info { "Loading trace $key at $pathToFile" }
-//
-//                    val trace = Trace.open(pathToFile, "opendc-vm")
-//                    val fragments = parseFragments(trace)
-//                    val vms = parseMeta(trace, fragments)
-//
-//                    SoftReference(vms)
-//                } else {
-//                    oldVal
-//                }
-//            }
-//
-//        return checkNotNull(ref?.get()) { "Memory pressure" }
     }
 
     /**

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/Task.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/Task.kt
@@ -45,7 +45,7 @@ public data class Task(
     val cpuCapacity: Double,
     val memCapacity: Long,
     val totalLoad: Double,
-    val submissionTime: Instant,
+    var submissionTime: Instant,
     val duration: Long,
     val trace: TraceWorkload,
 )

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/WorkloadSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/WorkloadSpec.kt
@@ -32,15 +32,20 @@ import java.io.File
  *
  * @property pathToFile
  * @property type
+ * @property sampleFraction
+ * @property submissionTime
  */
 @Serializable
 public data class WorkloadSpec(
     val pathToFile: String,
     val type: WorkloadTypes,
+    val sampleFraction: Double = 1.0,
+    val submissionTime: String? = null,
 ) {
     public val name: String = File(pathToFile).nameWithoutExtension
 
     init {
+        require(sampleFraction > 0) { "The fraction of the tasks can not be 0.0 or lower" }
         require(File(pathToFile).exists()) { "The provided path to the workload: $pathToFile does not exist " }
     }
 }
@@ -65,6 +70,7 @@ public enum class WorkloadTypes {
 public fun getWorkloadLoader(
     type: WorkloadTypes,
     pathToFile: File,
+    submissionTime: String?,
     checkpointInterval: Long,
     checkpointDuration: Long,
     checkpointIntervalScaling: Double,
@@ -73,6 +79,7 @@ public fun getWorkloadLoader(
         WorkloadTypes.ComputeWorkload ->
             ComputeWorkloadLoader(
                 pathToFile,
+                submissionTime,
                 checkpointInterval,
                 checkpointDuration,
                 checkpointIntervalScaling,

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioReplayer.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioReplayer.kt
@@ -139,9 +139,6 @@ public suspend fun ComputeService.replay(
 
                     // Wait until the task is terminated
                     taskWatcher.wait()
-
-                    // Stop the task after reaching the end-time of the virtual machine
-//                    task.delete()
                 }
             }
         }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
@@ -80,15 +80,6 @@ public fun runScenario(
             val checkpointDuration = scenario.checkpointModelSpec?.checkpointDuration ?: 0L
             val checkpointIntervalScaling = scenario.checkpointModelSpec?.checkpointIntervalScaling ?: 1.0
 
-//            val workloadLoader =
-//                ComputeWorkloadLoader(
-//                    File(scenario.workloadSpec.pathToFile),
-//                    checkpointInterval,
-//                    checkpointDuration,
-//                    checkpointIntervalScaling,
-//                )
-//            val tasks = getWorkloadType(scenario.workloadSpec.type).resolve(workloadLoader, Random(seed))
-
             val workloadLoader =
                 getWorkloadLoader(
                     scenario.workloadSpec.type,

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
@@ -93,11 +93,12 @@ public fun runScenario(
                 getWorkloadLoader(
                     scenario.workloadSpec.type,
                     File(scenario.workloadSpec.pathToFile),
+                    scenario.workloadSpec.submissionTime,
                     checkpointInterval,
                     checkpointDuration,
                     checkpointIntervalScaling,
                 )
-            val workload = workloadLoader.load()
+            val workload = workloadLoader.sampleByLoad(scenario.workloadSpec.sampleFraction)
 
             val startTimeLong = workload.minOf { it.submissionTime }.toEpochMilli()
             val startTime = Duration.ofMillis(startTimeLong)

--- a/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/OpenDCRunner.kt
+++ b/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/OpenDCRunner.kt
@@ -85,7 +85,7 @@ public class OpenDCRunner(
     /**
      * Helper class to load the workloads.
      */
-    private val workloadLoader = ComputeWorkloadLoader(tracePath, 0L, 0L, 0.0)
+    private val workloadLoader = ComputeWorkloadLoader(tracePath)
 
     /**
      * The [ForkJoinPool] that is used to execute the simulation jobs.


### PR DESCRIPTION
## Summary

Added sampleFraction and submissionTime to the workloadSpec.

sampleFraction can be used to randomly sample a subset of a workload. 
This can be useful when testing new features because it can significantly reduce the runtime.

submissionTime will shift the start of the workload to the given timestamp. 
This can be useful when exploring the effect of when  a workload is executed. 
submissionTime needs to be provided in the following format "YYYY-MM-DDThh:mm:ss"

## Implementation Notes :hammer_and_pick:

* Briefly outline the overall technical solution. If necessary, identify talking points where the reviewer's attention should be drawn to.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*