### PR TITLE
Added embodied carbon to batteries

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/HostsProvisioningStep.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/HostsProvisioningStep.kt
@@ -91,6 +91,8 @@ public class HostsProvisioningStep internal constructor(
                         cluster.battery!!.initialCharge,
                         cluster.battery!!.name,
                         cluster.name,
+                        cluster.battery!!.embodiedCarbon,
+                        cluster.battery!!.expectedLifetime,
                     )
                 graph.addEdge(battery, batteryDistributor)
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltBatteryExportColumns.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltBatteryExportColumns.kt
@@ -83,6 +83,11 @@ public object DfltBatteryExportColumns {
             field = Types.required(FLOAT).named("energy_usage"),
         ) { it.energyUsage }
 
+    public val EMBODIED_CARBON: ExportColumn<BatteryTableReader> =
+        ExportColumn(
+            field = Types.required(FLOAT).named("embodied_carbon_emission"),
+        ) { it.embodiedCarbonEmission }
+
     public val CHARGE: ExportColumn<BatteryTableReader> =
         ExportColumn(
             field = Types.required(FLOAT).named("charge"),

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/battery/BatteryTableReader.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/battery/BatteryTableReader.kt
@@ -51,11 +51,6 @@ public interface BatteryTableReader : Exportable {
     public val timestampAbsolute: Instant
 
     /**
-     * The number of connected hosts
-     */
-    public val hostsConnected: Int
-
-    /**
      * The current power draw of the host in W.
      */
     public val powerDraw: Double
@@ -65,9 +60,23 @@ public interface BatteryTableReader : Exportable {
      */
     public val energyUsage: Double
 
+    /**
+     * The embodied carbon cost of the Battery in kg
+     */
+    public val embodiedCarbonEmission: Double
+
+    /**
+     * The current state of the battery
+     */
     public val batteryState: BatteryState
 
+    /**
+     * The current charge of the battery in J
+     */
     public val charge: Double
 
+    /**
+     * The capacity of the battery in J
+     */
     public val capacity: Double
 }

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/battery/BatteryTableReaderImpl.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/battery/BatteryTableReaderImpl.kt
@@ -48,9 +48,9 @@ public class BatteryTableReaderImpl(
         _timestamp = table.timestamp
         _timestampAbsolute = table.timestampAbsolute
 
-        _hostsConnected = table.hostsConnected
         _powerDraw = table.powerDraw
         _energyUsage = table.energyUsage
+        _embodiedCarbonEmission = table.embodiedCarbonEmission
         _charge = table.charge
         _capacity = table.capacity
         _batteryState = table.batteryState
@@ -72,10 +72,6 @@ public class BatteryTableReaderImpl(
     override val timestampAbsolute: Instant
         get() = _timestampAbsolute
 
-    override val hostsConnected: Int
-        get() = _hostsConnected
-    private var _hostsConnected: Int = 0
-
     override val powerDraw: Double
         get() = _powerDraw
     private var _powerDraw = 0.0
@@ -84,6 +80,11 @@ public class BatteryTableReaderImpl(
         get() = _energyUsage - previousEnergyUsage
     private var _energyUsage = 0.0
     private var previousEnergyUsage = 0.0
+
+    override val embodiedCarbonEmission: Double
+        get() = _embodiedCarbonEmission - previousEmbodiedCarbonEmission
+    private var _embodiedCarbonEmission = 0.0
+    private var previousEmbodiedCarbonEmission = 0.0
 
     override val charge: Double
         get() = _charge
@@ -104,11 +105,10 @@ public class BatteryTableReaderImpl(
         _timestamp = now
         _timestampAbsolute = now + startTime
 
-        _hostsConnected = 0
-
         battery.updateCounters()
         _powerDraw = battery.outgoingSupply
         _energyUsage = battery.totalEnergyUsage
+        _embodiedCarbonEmission = battery.embodiedCarbonEmission
 
         _charge = battery.charge
         _capacity = battery.capacity
@@ -120,10 +120,11 @@ public class BatteryTableReaderImpl(
      */
     override fun reset() {
         previousEnergyUsage = _energyUsage
+        previousEmbodiedCarbonEmission = _embodiedCarbonEmission
 
-        _hostsConnected = 0
         _powerDraw = 0.0
         _energyUsage = 0.0
+        _embodiedCarbonEmission = 0.0
         _charge = 0.0
         _capacity = 0.0
         _batteryState = BatteryState.IDLE

--- a/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/TopologyFactories.kt
+++ b/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/TopologyFactories.kt
@@ -143,6 +143,8 @@ private fun ClusterJSONSpec.toClusterSpec(): ClusterSpec {
                 this.battery.chargingSpeed,
                 this.battery.batteryPolicy,
                 this.battery.initialCharge,
+                this.battery.embodiedCarbon,
+                this.battery.expectedLifetime,
             )
     }
 

--- a/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/BatterySpec.kt
+++ b/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/BatterySpec.kt
@@ -28,4 +28,6 @@ public data class BatterySpec(
     val chargingSpeed: Double,
     val batteryPolicy: BatteryPolicyJSONSpec,
     val initialCharge: Double,
+    val embodiedCarbon: Double,
+    val expectedLifetime: Double,
 )

--- a/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/TopologySpecs.kt
+++ b/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/TopologySpecs.kt
@@ -166,6 +166,9 @@ public data class PowerSourceJSONSpec(
  * @property chargingSpeed The charging speed of the battery in J
  * @property batteryPolicy The policy used to decide when the battery charges and discharges
  * @property initialCharge The initial charge in the battery
+ * @property embodiedCarbon The embodied carbon needed to create the battery in gram
+ * @property expectedLifetime The expected lifetime of the battery in years
+ *
  */
 @Serializable
 public data class BatteryJSONSpec(
@@ -174,12 +177,9 @@ public data class BatteryJSONSpec(
     val chargingSpeed: Double,
     val batteryPolicy: BatteryPolicyJSONSpec,
     var initialCharge: Double = 0.0,
-) {
-    init {
-        this.capacity *= 3600000
-        this.initialCharge *= 3600000
-    }
-}
+    var embodiedCarbon: Double = 0.0,
+    var expectedLifetime: Double = 0.0,
+)
 
 @Serializable
 public data class BatteryPolicyJSONSpec(


### PR DESCRIPTION
## Summary

Added support for embodied carbon of batteries to OpenDC. 

To use the embodied carbon of batteries, user have to provided two extra variables to the definition of the battery:
- "embodiedCarbon" defines the total carbon needed to create the battery in kg
- "expecctedLifeTime" defines the expected time the battery will be used in years 

OpenDC calculates two things: 
First, OpenDC determines the embodied carbon cost per milliseconds. 
Next, using the cost per ms, OpenDC can determine the embodied carbon per sample.


## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*