### PR TITLE
Fixed two bugs that could cause infinite loops

### DIFF
--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
@@ -124,6 +124,10 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
         long remainingDuration = this.scalingPolicy.getRemainingDuration(
                 this.cpuFreqDemand, this.newCpuFreqSupplied, this.remainingWork);
 
+        if (remainingDuration == 0.0) {
+            this.remainingWork = 0.0;
+        }
+
         return now + remainingDuration;
     }
 

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowDistributor.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowDistributor.java
@@ -39,8 +39,7 @@ public class FlowDistributor extends FlowNode implements FlowSupplier, FlowConsu
     private double currentIncomingSupply; // The current supply provided by the supplier
 
     private boolean outgoingDemandUpdateNeeded = false;
-    private final Set<Integer> updatedDemands =
-            new HashSet<>(); // Array of consumers that updated their demand in this cycle
+    private Set<Integer> updatedDemands = new HashSet<>(); // Array of consumers that updated their demand in this cycle
 
     private boolean overloaded = false;
 
@@ -209,13 +208,17 @@ public class FlowDistributor extends FlowNode implements FlowSupplier, FlowConsu
             other.setConsumerIndex(other.getConsumerIndex() - 1);
         }
 
-        for (int idx_other : this.updatedDemands) {
+        HashSet newUpdatedDemands = new HashSet<>();
 
+        for (int idx_other : this.updatedDemands) {
             if (idx_other > idx) {
-                this.updatedDemands.remove(idx_other);
-                this.updatedDemands.add(idx_other - 1);
+                newUpdatedDemands.add(idx_other - 1);
+            } else {
+                newUpdatedDemands.add(idx_other);
             }
         }
+
+        this.updatedDemands = newUpdatedDemands;
 
         this.outgoingDemandUpdateNeeded = true;
         this.invalidate();


### PR DESCRIPTION
## Summary

Fixed two bugs that could create infinite loops:

In SimTraceWorkload, it could be the case that the the remaining work for a trace is so small, that it would make the remaining duration also 0. In that case, it would look forever. I have added an extra check that solves this problem. 

In SimDistributor I was changing element of a Hashset while looping over the Hashset. This crashes java.
I solved this by creating a new Hashset.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*