### PR TITLE
Added the option to select which files to export.

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/ComputeMonitorProvisioningStep.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/ComputeMonitorProvisioningStep.kt
@@ -25,6 +25,7 @@ package org.opendc.compute.simulator.provisioner
 import org.opendc.compute.simulator.service.ComputeService
 import org.opendc.compute.simulator.telemetry.ComputeMetricReader
 import org.opendc.compute.simulator.telemetry.ComputeMonitor
+import org.opendc.compute.simulator.telemetry.OutputFiles
 import java.time.Duration
 
 /**
@@ -36,6 +37,14 @@ public class ComputeMonitorProvisioningStep(
     private val monitor: ComputeMonitor,
     private val exportInterval: Duration,
     private val startTime: Duration = Duration.ofMillis(0),
+    private val filesToExport: Map<OutputFiles, Boolean> =
+        mapOf(
+            OutputFiles.HOST to true,
+            OutputFiles.TASK to true,
+            OutputFiles.SERVICE to true,
+            OutputFiles.POWER_SOURCE to true,
+            OutputFiles.BATTERY to true,
+        ),
 ) : ProvisioningStep {
     override fun apply(ctx: ProvisioningContext): AutoCloseable {
         val service =
@@ -49,6 +58,7 @@ public class ComputeMonitorProvisioningStep(
                 monitor,
                 exportInterval,
                 startTime,
+                filesToExport,
             )
         return metricReader
     }

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/ComputeSteps.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/ComputeSteps.kt
@@ -26,6 +26,7 @@ package org.opendc.compute.simulator.provisioner
 
 import org.opendc.compute.simulator.scheduler.ComputeScheduler
 import org.opendc.compute.simulator.telemetry.ComputeMonitor
+import org.opendc.compute.simulator.telemetry.OutputFiles
 import org.opendc.compute.topology.specs.ClusterSpec
 import org.opendc.compute.topology.specs.HostSpec
 import java.time.Duration
@@ -59,8 +60,16 @@ public fun registerComputeMonitor(
     monitor: ComputeMonitor,
     exportInterval: Duration = Duration.ofMinutes(5),
     startTime: Duration = Duration.ofMillis(0),
+    filesToExport: Map<OutputFiles, Boolean> =
+        mapOf(
+            OutputFiles.HOST to true,
+            OutputFiles.TASK to true,
+            OutputFiles.SERVICE to true,
+            OutputFiles.POWER_SOURCE to true,
+            OutputFiles.BATTERY to true,
+        ),
 ): ProvisioningStep {
-    return ComputeMonitorProvisioningStep(serviceDomain, monitor, exportInterval, startTime)
+    return ComputeMonitorProvisioningStep(serviceDomain, monitor, exportInterval, startTime, filesToExport)
 }
 
 /**

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/OutputFiles.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/OutputFiles.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 AtLarge Research
+ * Copyright (c) 2025 AtLarge Research
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,31 +20,25 @@
  * SOFTWARE.
  */
 
-package org.opendc.experiments.base.experiment.specs
+package org.opendc.compute.simulator.telemetry
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import org.opendc.compute.simulator.telemetry.OutputFiles
-import org.opendc.compute.simulator.telemetry.parquet.ComputeExportConfig
 
-/**
- * specification describing how the results should be exported
- *
- * @property exportInterval The interval of exporting results in s. Should be higher than 0.0
- */
 @Serializable
-public data class ExportModelSpec(
-    val exportInterval: Long = 5 * 60,
-    val computeExportConfig: ComputeExportConfig = ComputeExportConfig.ALL_COLUMNS,
-    val filesToExport: List<OutputFiles> = OutputFiles.entries.toList(),
-    var filesToExportDict: MutableMap<OutputFiles, Boolean> = OutputFiles.entries.associateWith { false }.toMutableMap(),
-) {
-    init {
-        require(exportInterval > 0) { "The Export interval has to be higher than 0" }
+public enum class OutputFiles {
+    @SerialName("host")
+    HOST,
 
-        // Create a dictionary with each output file to false.
-        // Set each file in [filesToExport] to true in the dictionary.
-        for (file in filesToExport) {
-            filesToExportDict[file] = true
-        }
-    }
+    @SerialName("task")
+    TASK,
+
+    @SerialName("powerSource")
+    POWER_SOURCE,
+
+    @SerialName("battery")
+    BATTERY,
+
+    @SerialName("service")
+    SERVICE,
 }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/ExperimentFactories.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/ExperimentFactories.kt
@@ -75,7 +75,6 @@ public fun getExperiment(experimentSpec: ExperimentSpec): List<Scenario> {
                 outputFolder = outputFolder,
                 runs = experimentSpec.runs,
                 initialSeed = experimentSpec.initialSeed,
-                computeExportConfig = scenarioSpec.computeExportConfig,
                 topologySpec = scenarioSpec.topology,
                 workloadSpec = scenarioSpec.workload,
                 allocationPolicySpec = scenarioSpec.allocationPolicy,

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/Scenario.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/Scenario.kt
@@ -22,7 +22,6 @@
 
 package org.opendc.experiments.base.experiment
 
-import org.opendc.compute.simulator.telemetry.parquet.ComputeExportConfig
 import org.opendc.experiments.base.experiment.specs.AllocationPolicySpec
 import org.opendc.experiments.base.experiment.specs.CheckpointModelSpec
 import org.opendc.experiments.base.experiment.specs.ExportModelSpec
@@ -50,7 +49,6 @@ public data class Scenario(
     val outputFolder: String = "output",
     val runs: Int = 1,
     val initialSeed: Int = 0,
-    val computeExportConfig: ComputeExportConfig,
     val topologySpec: ScenarioTopologySpec,
     val workloadSpec: WorkloadSpec,
     val allocationPolicySpec: AllocationPolicySpec,

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/ExperimentSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/ExperimentSpec.kt
@@ -96,7 +96,6 @@ public data class ExperimentSpec(
                         id,
                         name,
                         outputFolder,
-                        computeExportConfig = computeExportConfig,
                         topologyList[(i / topologyDiv) % topologyList.size],
                         workloadList[(i / workloadDiv) % workloadList.size],
                         allocationPolicyList[(i / allocationDiv) % allocationPolicyList.size],

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/ScenarioSpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/ScenarioSpec.kt
@@ -23,14 +23,12 @@
 package org.opendc.experiments.base.experiment.specs
 
 import kotlinx.serialization.Serializable
-import org.opendc.compute.simulator.telemetry.parquet.ComputeExportConfig
 
 @Serializable
 public data class ScenarioSpec(
     var id: Int = -1,
     var name: String = "",
     val outputFolder: String = "output",
-    val computeExportConfig: ComputeExportConfig,
     val topology: ScenarioTopologySpec,
     val workload: WorkloadSpec,
     val allocationPolicy: AllocationPolicySpec = AllocationPolicySpec(),

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
@@ -147,10 +147,12 @@ public fun addExportModel(
                 File("${scenario.outputFolder}/raw-output/$index"),
                 "seed=$seed",
                 bufferSize = 4096,
-                computeExportConfig = scenario.computeExportConfig,
+                scenario.exportModelSpec.filesToExportDict,
+                computeExportConfig = scenario.exportModelSpec.computeExportConfig,
             ),
             Duration.ofSeconds(scenario.exportModelSpec.exportInterval),
             startTime,
+            scenario.exportModelSpec.filesToExportDict,
         ),
     )
 }


### PR DESCRIPTION
## Summary

Added the option to select which files to export.
The user can provide a list of files to export to the experiment json file which specifies which files to export.
If not specified, all files are exported. 

Example Json files:

```json
{
    "name": "surfsara_day",
    "topologies": [
        {
            "pathToFile": "topologies/batteries/surfsara_1000_10000_160.json"
        }
    ],
    "workloads": [
        {
            "pathToFile": "workload_traces/surfsara/2022-10-01_2022-10-02",
            "type": "ComputeWorkload"
        }
    ],
    "allocationPolicies": [{
        "policyType": "Mem"
    }],
    "exportModels": [
        {
            "exportInterval": 3600,
            "filesToExport": ["battery"],
        }
    ]
}
```

This experiment will only export the battery file. 
Using this can significantly reduce the size of the output files. 

Next to adding this option, "computeExportConfig" has been moved to the exportModel input. 

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

"computeExportConfig" is moved from the "experiment", to the "exportModel"

*Simply specify none (N/A) if not applicable.*