### PR TITLE
Fixed memorizing scheduler with correct last elem check

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/ComputeSchedulers.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/ComputeSchedulers.kt
@@ -44,6 +44,7 @@ public enum class ComputeSchedulerEnum {
     ProvisionedCores,
     ProvisionedCoresInv,
     Random,
+    TaskNumMemorizing
 }
 
 public fun createComputeScheduler(
@@ -108,6 +109,11 @@ public fun createComputeScheduler(
                 filters = listOf(ComputeFilter(), VCpuFilter(cpuAllocationRatio), RamFilter(ramAllocationRatio)),
                 weighers = emptyList(),
                 subsetSize = Int.MAX_VALUE,
+                random = SplittableRandom(seeder.nextLong()),
+            )
+        ComputeSchedulerEnum.TaskNumMemorizing ->
+            MemorizingScheduler(
+                filters = listOf(ComputeFilter(), VCpuFilter(cpuAllocationRatio), RamFilter(ramAllocationRatio)),
                 random = SplittableRandom(seeder.nextLong()),
             )
     }

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/ComputeSchedulers.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/ComputeSchedulers.kt
@@ -44,7 +44,7 @@ public enum class ComputeSchedulerEnum {
     ProvisionedCores,
     ProvisionedCoresInv,
     Random,
-    TaskNumMemorizing
+    TaskNumMemorizing,
 }
 
 public fun createComputeScheduler(

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
@@ -58,7 +58,7 @@ public class MemorizingScheduler(
         val listIdx = host.listIndex
         val chosenList = hostsQueue[priorityIdx]
 
-        if (listIdx == chosenList.size - 1) {
+        if (chosenList.size == 1) {
             chosenList.removeLast()
             if (listIdx == minAvailableHost) {
                 for (i in minAvailableHost + 1..hostsQueue.lastIndex) {
@@ -111,18 +111,19 @@ public class MemorizingScheduler(
         if (result == null) return SchedulingResult(SchedulingResultType.EMPTY) // No tasks to schedule that fit
 
         // Bookkeeping to maintain the calendar priority queue
-        val listIdx = chosenHost!!.listIndex
-
-        if (listIdx == chosenList!!.size - 1) {
+        if (chosenList!!.size == 1) {
             chosenList.removeLast()
-            if (chosenList.isEmpty()) minAvailableHost++
+            minAvailableHost++
         } else {
-            val lastItem = chosenList.removeLast()
+            val listIdx = chosenHost!!.listIndex
+            val lastItem = chosenList.last() // Not using removeLast here as it would cause problems during swapping
+                                             // if chosenHost is lastItem
             chosenList[listIdx] = lastItem
             lastItem.listIndex = listIdx
+            chosenList.removeLast()
         }
 
-        val nextList = hostsQueue[chosenHost.priorityIndex + 1]
+        val nextList = hostsQueue[chosenHost!!.priorityIndex + 1]
         nextList.add(chosenHost)
         chosenHost.priorityIndex++
         chosenHost.listIndex = nextList.size - 1
@@ -141,18 +142,20 @@ public class MemorizingScheduler(
         val chosenList = hostsQueue[priorityIdx]
         val nextList = hostsQueue[priorityIdx - 1]
 
-        if (listIdx == chosenList.size - 1) {
+        if (chosenList.size == 1) {
             chosenList.removeLast()
-            if (priorityIdx == minAvailableHost) {
-                minAvailableHost--
-            }
         } else {
-            val lastItem = chosenList.removeLast()
+            val lastItem = chosenList.last()
             chosenList[listIdx] = lastItem
             lastItem.listIndex = listIdx
+            chosenList.removeLast()
         }
+
         nextList.add(host)
         host.priorityIndex--
         host.listIndex = nextList.size - 1
+        if (priorityIdx == minAvailableHost) {
+            minAvailableHost--
+        }
     }
 }

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
@@ -116,8 +116,9 @@ public class MemorizingScheduler(
             minAvailableHost++
         } else {
             val listIdx = chosenHost!!.listIndex
-            val lastItem = chosenList.last() // Not using removeLast here as it would cause problems during swapping
-                                             // if chosenHost is lastItem
+            // Not using removeLast here as it would cause problems during swapping
+            // if chosenHost is lastItem
+            val lastItem = chosenList.last()
             chosenList[listIdx] = lastItem
             lastItem.listIndex = listIdx
             chosenList.removeLast()


### PR DESCRIPTION
## Summary

Memorizing scheduler had two bugs:
1. It assumed the chosenhost was the last one
2. It was removing elements before last element swap during deletion causing index out of range error

## Implementation Notes :hammer_and_pick:

Used correct last element check using size field.
Moved remove to after swapping last and chosen hosts.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*