### PR TITLE
Renamed SimChainWorkload to VirtualMachine

### DIFF
--- a/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/hostfault/StartStopHostFault.kt
+++ b/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/hostfault/StartStopHostFault.kt
@@ -41,7 +41,7 @@ public class StartStopHostFault(
         for (host in victims) {
             val guests = host.getGuests()
 
-            val snapshots = guests.map { it.simChainWorkload!!.getSnapshot() }
+            val snapshots = guests.map { it.virtualMachine!!.getSnapshot() }
             val tasks = guests.map { it.task }
             host.fail()
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/internal/Guest.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/internal/Guest.kt
@@ -31,7 +31,6 @@ import org.opendc.compute.simulator.telemetry.GuestSystemStats
 import org.opendc.simulator.compute.machine.SimMachine
 import org.opendc.simulator.compute.workload.ChainWorkload
 import org.opendc.simulator.compute.workload.VirtualMachine
-import org.opendc.simulator.compute.workload.trace.scaling.NoDelayScaling
 import java.time.Duration
 import java.time.Instant
 import java.time.InstantSource

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/internal/Guest.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/internal/Guest.kt
@@ -31,8 +31,6 @@ import org.opendc.compute.simulator.telemetry.GuestSystemStats
 import org.opendc.simulator.compute.machine.SimMachine
 import org.opendc.simulator.compute.workload.ChainWorkload
 import org.opendc.simulator.compute.workload.VirtualMachine
-import org.opendc.simulator.compute.workload.trace.TraceFragment
-import org.opendc.simulator.compute.workload.trace.TraceWorkload
 import org.opendc.simulator.compute.workload.trace.scaling.NoDelayScaling
 import java.time.Duration
 import java.time.Instant

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/internal/Guest.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/internal/Guest.kt
@@ -92,8 +92,6 @@ public class Guest(
 
         onStart()
 
-        val scalingPolicy = NoDelayScaling()
-
         // TODO: This is not being used at the moment
 //        val bootworkload =
 //            TraceWorkload(s
@@ -109,7 +107,7 @@ public class Guest(
 //                0,
 //                0,
 //                0.0,
-//                scalingPolicy,
+//                NoDelayScaling(),
 //            )
 
         if (task.workload is ChainWorkload) {

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/machine/SimMachine.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/machine/SimMachine.java
@@ -30,8 +30,8 @@ import org.opendc.simulator.compute.memory.Memory;
 import org.opendc.simulator.compute.models.MachineModel;
 import org.opendc.simulator.compute.power.SimPsu;
 import org.opendc.simulator.compute.workload.ChainWorkload;
-import org.opendc.simulator.compute.workload.SimChainWorkload;
 import org.opendc.simulator.compute.workload.SimWorkload;
+import org.opendc.simulator.compute.workload.VirtualMachine;
 import org.opendc.simulator.engine.engine.FlowEngine;
 import org.opendc.simulator.engine.graph.FlowDistributor;
 import org.opendc.simulator.engine.graph.FlowEdge;
@@ -74,10 +74,6 @@ public class SimMachine {
 
     public SimCpu getCpu() {
         return cpu;
-    }
-
-    public FlowDistributor getCpuDistributor() {
-        return cpuDistributor;
     }
 
     public Memory getMemory() {
@@ -180,11 +176,10 @@ public class SimMachine {
     /**
      * Create a Virtual Machine, and start the given workload on it.
      *
-     * @param workload
-     * @param completion
-     * @return
+     * @param workload The workload that needs to be executed
+     * @param completion The completion callback that needs to be called when the workload is done
      */
-    public SimChainWorkload startWorkload(ChainWorkload workload, Consumer<Exception> completion) {
-        return (SimChainWorkload) workload.startWorkload(this.cpuDistributor, this, completion);
+    public VirtualMachine startWorkload(ChainWorkload workload, Consumer<Exception> completion) {
+        return (VirtualMachine) workload.startWorkload(this.cpuDistributor, this, completion);
     }
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/ChainWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/ChainWorkload.java
@@ -27,38 +27,8 @@ import java.util.function.Consumer;
 import org.opendc.simulator.compute.machine.SimMachine;
 import org.opendc.simulator.engine.graph.FlowSupplier;
 
-public class ChainWorkload implements Workload {
-    private ArrayList<Workload> workloads;
-    private final long checkpointInterval;
-    private final long checkpointDuration;
-    private final double checkpointIntervalScaling;
-
-    public ChainWorkload(
-            ArrayList<Workload> workloads,
-            long checkpointInterval,
-            long checkpointDuration,
-            double checkpointIntervalScaling) {
-        this.workloads = workloads;
-        this.checkpointInterval = checkpointInterval;
-        this.checkpointDuration = checkpointDuration;
-        this.checkpointIntervalScaling = checkpointIntervalScaling;
-    }
-
-    public ArrayList<Workload> getWorkloads() {
-        return workloads;
-    }
-
-    public long getCheckpointInterval() {
-        return checkpointInterval;
-    }
-
-    public long getCheckpointDuration() {
-        return checkpointDuration;
-    }
-
-    public double getCheckpointIntervalScaling() {
-        return checkpointIntervalScaling;
-    }
+public record ChainWorkload(ArrayList<Workload> workloads, long checkpointInterval, long checkpointDuration,
+                            double checkpointIntervalScaling) implements Workload {
 
     public void removeWorkloads(int numberOfWorkloads) {
         if (numberOfWorkloads <= 0) {
@@ -69,11 +39,11 @@ public class ChainWorkload implements Workload {
 
     @Override
     public SimWorkload startWorkload(FlowSupplier supplier) {
-        return new SimChainWorkload(supplier, this);
+        return new VirtualMachine(supplier, this);
     }
 
     @Override
     public SimWorkload startWorkload(FlowSupplier supplier, SimMachine machine, Consumer<Exception> completion) {
-        return new SimChainWorkload(supplier, this, machine, completion);
+        return new VirtualMachine(supplier, this, machine, completion);
     }
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/ChainWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/ChainWorkload.java
@@ -27,8 +27,12 @@ import java.util.function.Consumer;
 import org.opendc.simulator.compute.machine.SimMachine;
 import org.opendc.simulator.engine.graph.FlowSupplier;
 
-public record ChainWorkload(ArrayList<Workload> workloads, long checkpointInterval, long checkpointDuration,
-                            double checkpointIntervalScaling) implements Workload {
+public record ChainWorkload(
+        ArrayList<Workload> workloads,
+        long checkpointInterval,
+        long checkpointDuration,
+        double checkpointIntervalScaling)
+        implements Workload {
 
     public void removeWorkloads(int numberOfWorkloads) {
         if (numberOfWorkloads <= 0) {

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/Workload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/Workload.java
@@ -28,11 +28,11 @@ import org.opendc.simulator.engine.graph.FlowSupplier;
 
 public interface Workload {
 
-    long getCheckpointInterval();
+    long checkpointInterval();
 
-    long getCheckpointDuration();
+    long checkpointDuration();
 
-    double getCheckpointIntervalScaling();
+    double checkpointIntervalScaling();
 
     SimWorkload startWorkload(FlowSupplier supplier);
 

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
@@ -51,7 +51,7 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
 
     private final TraceWorkload snapshot;
 
-    private ScalingPolicy scalingPolicy = new NoDelayScaling();
+    private final ScalingPolicy scalingPolicy;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Basic Getters and Setters

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
@@ -26,7 +26,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.opendc.simulator.compute.workload.SimWorkload;
-import org.opendc.simulator.compute.workload.trace.scaling.NoDelayScaling;
 import org.opendc.simulator.compute.workload.trace.scaling.ScalingPolicy;
 import org.opendc.simulator.engine.graph.FlowConsumer;
 import org.opendc.simulator.engine.graph.FlowEdge;

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
@@ -88,7 +88,7 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
         super(((FlowNode) supplier).getEngine());
 
         this.snapshot = workload;
-        this.checkpointDuration = workload.getCheckpointDuration();
+        this.checkpointDuration = workload.checkpointDuration();
         this.scalingPolicy = workload.getScalingPolicy();
         this.remainingFragments = new LinkedList<>(workload.getFragments());
         this.fragmentIndex = 0;

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import org.opendc.simulator.compute.machine.SimMachine;
 import org.opendc.simulator.compute.workload.SimWorkload;
 import org.opendc.simulator.compute.workload.Workload;
-import org.opendc.simulator.compute.workload.trace.scaling.NoDelayScaling;
 import org.opendc.simulator.compute.workload.trace.scaling.ScalingPolicy;
 import org.opendc.simulator.engine.graph.FlowSupplier;
 
@@ -115,10 +114,6 @@ public class TraceWorkload implements Workload {
     @Override
     public SimWorkload startWorkload(FlowSupplier supplier, SimMachine machine, Consumer<Exception> completion) {
         return this.startWorkload(supplier);
-    }
-
-    public static Builder builder() {
-        return builder(0L, 0L, 0.0, new NoDelayScaling());
     }
 
     public static Builder builder(

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
@@ -79,17 +79,17 @@ public class TraceWorkload implements Workload {
     }
 
     @Override
-    public long getCheckpointInterval() {
+    public long checkpointInterval() {
         return checkpointInterval;
     }
 
     @Override
-    public long getCheckpointDuration() {
+    public long checkpointDuration() {
         return checkpointDuration;
     }
 
     @Override
-    public double getCheckpointIntervalScaling() {
+    public double checkpointIntervalScaling() {
         return checkpointIntervalScaling;
     }
 

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
@@ -34,7 +34,7 @@ import org.opendc.simulator.compute.workload.trace.scaling.ScalingPolicy;
 import org.opendc.simulator.engine.graph.FlowSupplier;
 
 public class TraceWorkload implements Workload {
-    private ArrayList<TraceFragment> fragments;
+    private final ArrayList<TraceFragment> fragments;
     private final long checkpointInterval;
     private final long checkpointDuration;
     private final double checkpointIntervalScaling;
@@ -68,10 +68,6 @@ public class TraceWorkload implements Workload {
                 .max(Comparator.comparing(TraceFragment::coreCount))
                 .get()
                 .coreCount();
-    }
-
-    public TraceWorkload(ArrayList<TraceFragment> fragments) {
-        this(fragments, 0L, 0L, 1.0, new NoDelayScaling());
     }
 
     public ArrayList<TraceFragment> getFragments() {
@@ -109,7 +105,7 @@ public class TraceWorkload implements Workload {
     }
 
     public void addFirst(TraceFragment fragment) {
-        this.fragments.add(0, fragment);
+        this.fragments.addFirst(fragment);
     }
 
     @Override
@@ -132,36 +128,6 @@ public class TraceWorkload implements Workload {
             double checkpointIntervalScaling,
             ScalingPolicy scalingPolicy) {
         return new Builder(checkpointInterval, checkpointDuration, checkpointIntervalScaling, scalingPolicy);
-    }
-
-    /**
-     * Construct a {@link TraceWorkload} from the specified fragments.
-     *
-     * @param fragments The array of fragments to construct the trace from.
-     */
-    public static TraceWorkload ofFragments(TraceFragment... fragments) {
-        final Builder builder = builder();
-
-        for (TraceFragment fragment : fragments) {
-            builder.add(fragment.duration(), fragment.cpuUsage(), fragment.coreCount());
-        }
-
-        return builder.build();
-    }
-
-    /**
-     * Construct a {@link TraceWorkload} from the specified fragments.
-     *
-     * @param fragments The fragments to construct the trace from.
-     */
-    public static TraceWorkload ofFragments(List<TraceFragment> fragments) {
-        final Builder builder = builder();
-
-        for (TraceFragment fragment : fragments) {
-            builder.add(fragment.duration(), fragment.cpuUsage(), fragment.coreCount());
-        }
-
-        return builder.build();
     }
 
     public static final class Builder {

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
@@ -24,7 +24,6 @@ package org.opendc.simulator.compute.workload.trace;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
 import java.util.function.Consumer;
 import org.opendc.simulator.compute.machine.SimMachine;
 import org.opendc.simulator.compute.workload.SimWorkload;


### PR DESCRIPTION
## Summary

Renamed SimChainWorkload to VirtualMachine. 

Also updated some small code issues.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A 

## Breaking API Changes :warning:

SimChainWorkload is now called VirtualMachine

*Simply specify none (N/A) if not applicable.*