### PR TITLE
Added embodied carbon to hosts

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ComputeService.java
+++ b/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ComputeService.java
@@ -23,7 +23,6 @@
 package org.opendc.compute.simulator.service;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.time.InstantSource;
 import java.time.temporal.TemporalAmount;
 import java.util.ArrayDeque;
@@ -128,6 +127,7 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
 
     /**
      * The active tasks in the system.
+     * TODO: this is not doing anything, maybe delete it?
      */
     private final Map<ServiceTask, SimHost> completedTasks = new HashMap<>();
 
@@ -407,7 +407,6 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
     /**
      * Enqueue the specified [task] to be scheduled onto a host.
      */
-
     SchedulingRequest schedule(ServiceTask task) {
         return schedule(task, false);
     }
@@ -491,18 +490,19 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
 
             final ServiceFlavor flavor = task.getFlavor();
 
-//            if (task.getNumFailures() >= maxNumFailures) {
-//                LOGGER.warn("task {} has been terminated because it failed {} times", task, task.getNumFailures());
-//
-//                taskQueue.remove(req);
-//                tasksPending--;
-//                tasksTerminated++;
-//                task.setState(TaskState.TERMINATED);
-//
-//                scheduler.removeTask(task, hv);
-//                this.setTaskToBeRemoved(task);
-//                continue;
-//            }
+            //            if (task.getNumFailures() >= maxNumFailures) {
+            //                LOGGER.warn("task {} has been terminated because it failed {} times", task,
+            // task.getNumFailures());
+            //
+            //                taskQueue.remove(req);
+            //                tasksPending--;
+            //                tasksTerminated++;
+            //                task.setState(TaskState.TERMINATED);
+            //
+            //                scheduler.removeTask(task, hv);
+            //                this.setTaskToBeRemoved(task);
+            //                continue;
+            //            }
 
             if (result.getResultType() == SchedulingResultType.FAILURE) {
                 LOGGER.trace("Task {} selected for scheduling but no capacity available for it at the moment", task);

--- a/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ServiceTask.java
+++ b/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ServiceTask.java
@@ -185,7 +185,7 @@ public class ServiceTask {
             case FAILED:
                 LOGGER.info("User requested to start task after failure {}", uid);
                 setState(TaskState.PROVISIONING);
-                request = service.schedule(this);
+                request = service.schedule(this, true);
                 break;
         }
     }

--- a/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/telemetry/HostSystemStats.java
+++ b/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/telemetry/HostSystemStats.java
@@ -44,6 +44,7 @@ public record HostSystemStats(
         Instant bootTime,
         double powerDraw,
         double energyUsage,
+        double embodiedCarbon,
         int guestsTerminated,
         int guestsRunning,
         int guestsError,

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/host/SimHost.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/host/SimHost.kt
@@ -46,7 +46,6 @@ import java.time.InstantSource
  *
  * @param name The name of the host.
  * @param clock The (virtual) clock used to track time.
- * @param graph The Flow Graph that the Host is part of
  * @param machineModel The static model of the host
  * @param cpuPowerModel The power model of the host
  * @param powerDistributor The power distributor to which the host is connected
@@ -111,7 +110,7 @@ public class SimHost(
     private var bootTime: Instant? = null
     private val cpuLimit = machineModel.cpuModel.totalCapacity
 
-    private var embodiedCarbonRate: Double = 0.0;
+    private var embodiedCarbonRate: Double = 0.0
 
     init {
         launch()
@@ -123,7 +122,6 @@ public class SimHost(
     private fun launch() {
         this.embodiedCarbonRate =
             (this.embodiedCarbon * 1000) / (this.expectedLifetime * 365.0 * 24.0 * 60.0 * 60.0 * 1000.0)
-
 
         bootTime = this.clock.instant()
         hostState = HostState.UP
@@ -277,7 +275,7 @@ public class SimHost(
         updateUptime()
         this.simMachine!!.psu.updateCounters()
 
-        var terminated = 0
+        val terminated = 0
         var running = 0
         var failed = 0
         var invalid = 0
@@ -303,7 +301,7 @@ public class SimHost(
             bootTime,
             simMachine!!.psu.powerDraw,
             simMachine!!.psu.energyUsage,
-            embodiedCarbonRate* duration,
+            embodiedCarbonRate * duration,
             terminated,
             running,
             failed,

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/HostsProvisioningStep.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/HostsProvisioningStep.kt
@@ -133,6 +133,8 @@ public class HostsProvisioningStep internal constructor(
                         engine,
                         hostSpec.model,
                         hostSpec.cpuPowerModel,
+                        hostSpec.embodiedCarbon,
+                        hostSpec.expectedLifetime,
                         hostDistributor,
                     )
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
@@ -40,7 +40,7 @@ public class MemorizingScheduler(
 ) : ComputeScheduler {
     // We assume that there will be max 200 tasks per host.
     // The index of a host list is the number of tasks on that host.
-    private val hostsQueue = List(200, { mutableListOf<HostView>() })
+    private val hostsQueue = List(20000, { mutableListOf<HostView>() })
     private var minAvailableHost = 0
     private var numHosts = 0
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltHostExportColumns.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltHostExportColumns.kt
@@ -154,6 +154,11 @@ public object DfltHostExportColumns {
             field = Types.required(FLOAT).named("energy_usage"),
         ) { it.energyUsage }
 
+    public val EMBODIED_CARBON: ExportColumn<HostTableReader> =
+        ExportColumn(
+            field = Types.required(FLOAT).named("embodied_carbon"),
+        ) { it.embodiedCarbon }
+
     public val UP_TIME: ExportColumn<HostTableReader> =
         ExportColumn(
             field = Types.required(INT64).named("uptime"),

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltTaskExportColumns.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltTaskExportColumns.kt
@@ -165,6 +165,6 @@ public object DfltTaskExportColumns {
             TIMESTAMP_ABS,
             TIMESTAMP,
             TASK_ID,
-            TASK_NAME
+            TASK_NAME,
         )
 }

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltTaskExportColumns.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltTaskExportColumns.kt
@@ -66,14 +66,6 @@ public object DfltTaskExportColumns {
                     .named("task_id"),
         ) { Binary.fromString(it.taskInfo.id) }
 
-//    public val HOST_ID: ExportColumn<TaskTableReader> =
-//        ExportColumn(
-//            field =
-//                Types.optional(BINARY)
-//                    .`as`(LogicalTypeAnnotation.stringType())
-//                    .named("host_id"),
-//        ) { it.host?.id?.let { Binary.fromString(it) } }
-
     public val TASK_NAME: ExportColumn<TaskTableReader> =
         ExportColumn(
             field =
@@ -137,10 +129,10 @@ public object DfltTaskExportColumns {
             field = Types.required(INT64).named("downtime"),
         ) { it.downtime }
 
-    public val PROVISION_TIME: ExportColumn<TaskTableReader> =
+    public val NUM_FAILURES: ExportColumn<TaskTableReader> =
         ExportColumn(
-            field = Types.optional(INT64).named("provision_time"),
-        ) { it.provisionTime?.toEpochMilli() }
+            field = Types.required(INT64).named("num_failures"),
+        ) { it.numFailures }
 
     public val SCHEDULE_TIME: ExportColumn<TaskTableReader> =
         ExportColumn(
@@ -172,5 +164,7 @@ public object DfltTaskExportColumns {
         setOf(
             TIMESTAMP_ABS,
             TIMESTAMP,
+            TASK_ID,
+            TASK_NAME
         )
 }

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/host/HostTableReader.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/host/HostTableReader.kt
@@ -123,6 +123,11 @@ public interface HostTableReader : Exportable {
     public val energyUsage: Double
 
     /**
+     * The embodied carbon emitted since the last sample in gram.
+     */
+    public val embodiedCarbon: Double
+
+    /**
      * The uptime of the host since last time in ms.
      */
     public val uptime: Long

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/host/HostTableReaderImpl.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/host/HostTableReaderImpl.kt
@@ -59,6 +59,7 @@ public class HostTableReaderImpl(
         _cpuLostTime = table.cpuLostTime
         _powerDraw = table.powerDraw
         _energyUsage = table.energyUsage
+        _embodiedCarbon = table.embodiedCarbon
         _uptime = table.uptime
         _downtime = table.downtime
         _bootTime = table.bootTime
@@ -143,6 +144,10 @@ public class HostTableReaderImpl(
     private var _energyUsage = 0.0
     private var previousEnergyUsage = 0.0
 
+    override val embodiedCarbon: Double
+        get() = _embodiedCarbon
+    private var _embodiedCarbon = 0.0
+
     override val uptime: Long
         get() = _uptime - previousUptime
     private var _uptime = 0L
@@ -181,6 +186,7 @@ public class HostTableReaderImpl(
         _cpuLostTime = hostCpuStats.lostTime
         _powerDraw = hostSysStats.powerDraw
         _energyUsage = hostSysStats.energyUsage
+        _embodiedCarbon = hostSysStats.embodiedCarbon
         _uptime = hostSysStats.uptime.toMillis()
         _downtime = hostSysStats.downtime.toMillis()
         _bootTime = hostSysStats.bootTime
@@ -212,5 +218,6 @@ public class HostTableReaderImpl(
 
         _powerDraw = 0.0
         _energyUsage = 0.0
+        _embodiedCarbon = 0.0
     }
 }

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReader.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReader.kt
@@ -71,9 +71,9 @@ public interface TaskTableReader : Exportable {
     public val downtime: Long
 
     /**
-     * The [Instant] at which the task was enqueued for the scheduler.
+     * The number of times the task has been kicked from a host due to failures
      */
-    public val provisionTime: Instant?
+    public val numFailures: Int
 
     /**
      * The [Instant] at which the task was scheduled relative to the start of the workload.
@@ -86,7 +86,7 @@ public interface TaskTableReader : Exportable {
     public val submissionTime: Instant?
 
     /**
-     * The [Instant] at which the task booted relative to the start of the workload.
+     * The [Instant] at which the task finished relative to the start of the workload.
      */
     public val finishTime: Instant?
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReaderImpl.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReaderImpl.kt
@@ -64,7 +64,7 @@ public class TaskTableReaderImpl(
         _cpuLostTime = table.cpuLostTime
         _uptime = table.uptime
         _downtime = table.downtime
-        _provisionTime = table.provisionTime
+        _numFailures = table.numFailures
         _scheduleTime = table.scheduleTime
 
         _submissionTime = table.submissionTime
@@ -110,17 +110,17 @@ public class TaskTableReaderImpl(
     private var _downtime: Long = 0
     private var previousDowntime = 0L
 
-    override val provisionTime: Instant?
-        get() = _provisionTime
-    private var _provisionTime: Instant? = null
-
-    override val scheduleTime: Instant?
-        get() = _scheduleTime
-    private var _scheduleTime: Instant? = null
+    override val numFailures: Int
+        get() = _numFailures
+    private var _numFailures = 0
 
     override val submissionTime: Instant?
         get() = _submissionTime
     private var _submissionTime: Instant? = null
+
+    override val scheduleTime: Instant?
+        get() = _scheduleTime
+    private var _scheduleTime: Instant? = null
 
     override val finishTime: Instant?
         get() = _finishTime
@@ -195,9 +195,10 @@ public class TaskTableReaderImpl(
         _cpuLostTime = cpuStats?.lostTime ?: _cpuLostTime
         _uptime = sysStats?.uptime?.toMillis() ?: _uptime
         _downtime = sysStats?.downtime?.toMillis() ?: _downtime
-        _provisionTime = task.scheduledAt
-        _scheduleTime = sysStats?.bootTime ?: _scheduleTime
+
+        _numFailures = task.numFailures
         _submissionTime = task.submittedAt
+        _scheduleTime = task.scheduledAt
         _finishTime = task.finishedAt
 
         _taskState = task.state

--- a/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/BatterySpec.kt
+++ b/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/BatterySpec.kt
@@ -28,6 +28,6 @@ public data class BatterySpec(
     val chargingSpeed: Double,
     val batteryPolicy: BatteryPolicyJSONSpec,
     val initialCharge: Double,
-    val embodiedCarbon: Double,
-    val expectedLifetime: Double,
+    val embodiedCarbon: Double = 1000.0,
+    val expectedLifetime: Double = 10.0,
 )

--- a/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/HostSpec.kt
+++ b/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/HostSpec.kt
@@ -37,4 +37,6 @@ public data class HostSpec(
     val clusterName: String,
     val model: MachineModel,
     val cpuPowerModel: CpuPowerModel,
+    val embodiedCarbon: Double = 1000.0,
+    val expectedLifetime: Double = 5.0,
 )

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
@@ -93,7 +93,7 @@ public class ComputeWorkloadLoader(
                 val builder =
                     fragments.computeIfAbsent(
                         id,
-                    ) { Builder(checkpointInterval, checkpointDuration, checkpointIntervalScaling, scalingPolicy) }
+                    ) { Builder(checkpointInterval, checkpointDuration, checkpointIntervalScaling, scalingPolicy, id) }
                 builder.add(durationMs, cpuUsage, cores)
             }
 
@@ -202,6 +202,7 @@ public class ComputeWorkloadLoader(
         checkpointDuration: Long,
         checkpointIntervalScaling: Double,
         scalingPolicy: ScalingPolicy,
+        taskName: String,
     ) {
         /**
          * The total load of the trace.
@@ -211,7 +212,7 @@ public class ComputeWorkloadLoader(
         /**
          * The internal builder for the trace.
          */
-        private val builder = TraceWorkload.builder(checkpointInterval, checkpointDuration, checkpointIntervalScaling, scalingPolicy)
+        private val builder = TraceWorkload.builder(checkpointInterval, checkpointDuration, checkpointIntervalScaling, scalingPolicy, taskName)
 
         /**
          * Add a fragment to the trace.

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
@@ -49,7 +49,6 @@ import kotlin.math.roundToLong
 /**
  * A helper class for loading compute workload traces into memory.
  *
- * @param baseDir The directory containing the traces.
  */
 public class ComputeWorkloadLoader(
     private val pathToFile: File,
@@ -212,7 +211,14 @@ public class ComputeWorkloadLoader(
         /**
          * The internal builder for the trace.
          */
-        private val builder = TraceWorkload.builder(checkpointInterval, checkpointDuration, checkpointIntervalScaling, scalingPolicy, taskName)
+        private val builder =
+            TraceWorkload.builder(
+                checkpointInterval,
+                checkpointDuration,
+                checkpointIntervalScaling,
+                scalingPolicy,
+                taskName,
+            )
 
         /**
          * Add a fragment to the trace.

--- a/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/TestingUtils.kt
+++ b/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/TestingUtils.kt
@@ -90,7 +90,7 @@ fun createTestTask(
             checkpointDuration,
             checkpointIntervalScaling,
             scalingPolicy,
-            name
+            name,
         ),
     )
 }

--- a/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/TestingUtils.kt
+++ b/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/TestingUtils.kt
@@ -90,6 +90,7 @@ fun createTestTask(
             checkpointDuration,
             checkpointIntervalScaling,
             scalingPolicy,
+            name
         ),
     )
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/VirtualMachine.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/VirtualMachine.java
@@ -194,7 +194,6 @@ public final class VirtualMachine extends SimWorkload implements FlowSupplier {
         }
 
         this.closeNode();
-
         if (this.completion != null) {
             this.completion.accept(stopWorkloadCause);
             this.completion = null;

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
@@ -52,6 +52,8 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
 
     private final ScalingPolicy scalingPolicy;
 
+    private final String taskName;
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Basic Getters and Setters
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -91,6 +93,9 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
         this.scalingPolicy = workload.getScalingPolicy();
         this.remainingFragments = new LinkedList<>(workload.getFragments());
         this.fragmentIndex = 0;
+        this.taskName = workload.getTaskName();
+
+        this.startOfFragment = this.clock.millis();
 
         new FlowEdge(this, supplier);
     }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
@@ -39,6 +39,12 @@ public class TraceWorkload implements Workload {
     private final double maxCpuDemand;
     private final int maxCoreCount;
 
+    public String getTaskName() {
+        return taskName;
+    }
+
+    private final String taskName;
+
     public ScalingPolicy getScalingPolicy() {
         return scalingPolicy;
     }
@@ -50,12 +56,14 @@ public class TraceWorkload implements Workload {
             long checkpointInterval,
             long checkpointDuration,
             double checkpointIntervalScaling,
-            ScalingPolicy scalingPolicy) {
+            ScalingPolicy scalingPolicy,
+            String taskName) {
         this.fragments = fragments;
         this.checkpointInterval = checkpointInterval;
         this.checkpointDuration = checkpointDuration;
         this.checkpointIntervalScaling = checkpointIntervalScaling;
         this.scalingPolicy = scalingPolicy;
+        this.taskName = taskName;
 
         // TODO: remove if we decide not to use it.
         this.maxCpuDemand = fragments.stream()
@@ -120,8 +128,9 @@ public class TraceWorkload implements Workload {
             long checkpointInterval,
             long checkpointDuration,
             double checkpointIntervalScaling,
-            ScalingPolicy scalingPolicy) {
-        return new Builder(checkpointInterval, checkpointDuration, checkpointIntervalScaling, scalingPolicy);
+            ScalingPolicy scalingPolicy,
+            String taskName) {
+        return new Builder(checkpointInterval, checkpointDuration, checkpointIntervalScaling, scalingPolicy, taskName);
     }
 
     public static final class Builder {
@@ -130,6 +139,7 @@ public class TraceWorkload implements Workload {
         private final long checkpointDuration;
         private final double checkpointIntervalScaling;
         private final ScalingPolicy scalingPolicy;
+        private final String taskName;
 
         /**
          * Construct a new {@link Builder} instance.
@@ -138,12 +148,14 @@ public class TraceWorkload implements Workload {
                 long checkpointInterval,
                 long checkpointDuration,
                 double checkpointIntervalScaling,
-                ScalingPolicy scalingPolicy) {
+                ScalingPolicy scalingPolicy,
+                String taskName) {
             this.fragments = new ArrayList<>();
             this.checkpointInterval = checkpointInterval;
             this.checkpointDuration = checkpointDuration;
             this.checkpointIntervalScaling = checkpointIntervalScaling;
             this.scalingPolicy = scalingPolicy;
+            this.taskName = taskName;
         }
 
         /**
@@ -166,7 +178,8 @@ public class TraceWorkload implements Workload {
                     this.checkpointInterval,
                     this.checkpointDuration,
                     this.checkpointIntervalScaling,
-                    this.scalingPolicy);
+                    this.scalingPolicy,
+                    this.taskName);
         }
     }
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/scaling/NoDelayScaling.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/scaling/NoDelayScaling.java
@@ -32,16 +32,16 @@ package org.opendc.simulator.compute.workload.trace.scaling;
 public class NoDelayScaling implements ScalingPolicy {
     @Override
     public double getFinishedWork(double cpuFreqDemand, double cpuFreqSupplied, long passedTime) {
-        return cpuFreqDemand * passedTime;
+        return passedTime;
     }
 
     @Override
     public long getRemainingDuration(double cpuFreqDemand, double cpuFreqSupplied, double remainingWork) {
-        return (long) (remainingWork / cpuFreqDemand);
+        return (long) remainingWork;
     }
 
     @Override
     public double getRemainingWork(double cpuFreqDemand, long duration) {
-        return cpuFreqDemand * duration;
+        return duration;
     }
 }


### PR DESCRIPTION
## Summary

This PR adds several small changes to OpenDC:

1.  Added embodied Carbon to hosts. 
Similar to Batteries, users can specify the total embodied carbon cost to a host, and the expected lifetime. 

When logging, OpenDC determines the portion of the lifetime, the host is used and calculates the embodied carbon based on that.

2. I moved the termination of tasks to after the failure instead of when trying to reschedule. This should only make a difference in a small number of cases.

3. Added number of failures of a task as an optional logging column

4. Fixed a minor bug in NoScalingPolicy that could create issues when dealing with fragments with a cpu_usage of 0.0.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A 

## Breaking API Changes :warning:

Embodied Carbon is optional. If not added, it is set to 1000 kgCO2 and a lifetime of 5 years.

*Simply specify none (N/A) if not applicable.*