### PR TITLE
Fixed a small problem with getForeCast

### DIFF
--- a/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/victimselector/StochasticVictimSelector.kt
+++ b/opendc-compute/opendc-compute-failure/src/main/kotlin/org/opendc/compute/failure/victimselector/StochasticVictimSelector.kt
@@ -27,6 +27,7 @@ import java.util.SplittableRandom
 import java.util.random.RandomGenerator
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 /**
  * A [VictimSelector] that stochastically selects a set of hosts to be failed.
@@ -73,7 +74,7 @@ public class StochasticVictimSelector(
     ): List<SimHost> {
         // clamp value between 0.0 and 1.0
         val intensity = min(1.0, max(0.0, failureIntensity))
-        val numberOfHosts = (hosts.size * intensity).toInt()
+        val numberOfHosts = (hosts.size * intensity).roundToInt()
 
         return hosts.asSequence().shuffled().take(numberOfHosts).toList()
     }

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
@@ -40,7 +40,7 @@ public class MemorizingScheduler(
 ) : ComputeScheduler {
     // We assume that there will be max 200 tasks per host.
     // The index of a host list is the number of tasks on that host.
-    private val hostsQueue = List(20000, { mutableListOf<HostView>() })
+    private val hostsQueue = List(100, { mutableListOf<HostView>() })
     private var minAvailableHost = 0
     private var numHosts = 0
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/TaskStopper.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/TaskStopper.kt
@@ -79,7 +79,9 @@ public class TaskStopper(
             isHighCarbon = noForecastUpdateCarbonIntensity(newCarbonIntensity)
         } else {
             val forecast = carbonModel!!.getForecast(forecastSize)
-            val quantileIndex = (forecastSize * forecastThreshold).roundToInt()
+
+            val localForecastSize = forecast.size
+            val quantileIndex = (localForecastSize * forecastThreshold).roundToInt()
             val thresholdCarbonIntensity = forecast.sorted()[quantileIndex]
 
             isHighCarbon = newCarbonIntensity > thresholdCarbonIntensity

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/TimeshiftScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/TimeshiftScheduler.kt
@@ -171,10 +171,11 @@ public class TimeshiftScheduler(
         }
 
         val forecast = carbonModel!!.getForecast(forecastSize)
-        val forecastSize = forecast.size
-        val shortQuantileIndex = (forecastSize * shortForecastThreshold).roundToInt()
+        val localForecastSize = forecast.size
+
+        val shortQuantileIndex = (localForecastSize * shortForecastThreshold).roundToInt()
         val shortCarbonIntensity = forecast.sorted()[shortQuantileIndex]
-        val longQuantileIndex = (forecastSize * longForecastThreshold).roundToInt()
+        val longQuantileIndex = (localForecastSize * longForecastThreshold).roundToInt()
         val longCarbonIntensity = forecast.sorted()[longQuantileIndex]
 
         shortLowCarbon = newCarbonIntensity < shortCarbonIntensity

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/power/CarbonModel.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/power/CarbonModel.java
@@ -136,8 +136,8 @@ public class CarbonModel extends FlowNode {
     }
 
     public double[] getForecast(int forecastSize) {
-        return this.fragments.subList(Math.max(this.fragment_index + 1, this.fragments.size() - 1),
-                                      Math.max(this.fragment_index + forecastSize, this.fragments.size())).stream()
+        return this.fragments.subList(Math.min(this.fragment_index + 1, this.fragments.size() - 1),
+                                      Math.min(this.fragment_index + forecastSize, this.fragments.size())).stream()
                 .mapToDouble(CarbonFragment::getCarbonIntensity)
                 .toArray();
     }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/power/CarbonModel.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/power/CarbonModel.java
@@ -29,6 +29,8 @@ import org.opendc.simulator.engine.engine.FlowEngine;
 import org.opendc.simulator.engine.graph.FlowEdge;
 import org.opendc.simulator.engine.graph.FlowNode;
 
+import static java.util.Collections.max;
+
 /**
  * CarbonModel used to provide the Carbon Intensity of a {@link SimPowerSource}
  * A CarbonModel is based on a list of {@link CarbonFragment} that define the carbon intensity at specific time frames.
@@ -134,7 +136,8 @@ public class CarbonModel extends FlowNode {
     }
 
     public double[] getForecast(int forecastSize) {
-        return this.fragments.subList(this.fragment_index + 1, this.fragment_index + forecastSize).stream()
+        return this.fragments.subList(Math.max(this.fragment_index + 1, this.fragments.size() - 1),
+                                      Math.max(this.fragment_index + forecastSize, this.fragments.size())).stream()
                 .mapToDouble(CarbonFragment::getCarbonIntensity)
                 .toArray();
     }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/power/CarbonModel.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/power/CarbonModel.java
@@ -29,8 +29,6 @@ import org.opendc.simulator.engine.engine.FlowEngine;
 import org.opendc.simulator.engine.graph.FlowEdge;
 import org.opendc.simulator.engine.graph.FlowNode;
 
-import static java.util.Collections.max;
-
 /**
  * CarbonModel used to provide the Carbon Intensity of a {@link SimPowerSource}
  * A CarbonModel is based on a list of {@link CarbonFragment} that define the carbon intensity at specific time frames.
@@ -136,8 +134,11 @@ public class CarbonModel extends FlowNode {
     }
 
     public double[] getForecast(int forecastSize) {
-        return this.fragments.subList(Math.min(this.fragment_index + 1, this.fragments.size() - 1),
-                                      Math.min(this.fragment_index + forecastSize, this.fragments.size())).stream()
+        return this.fragments
+                .subList(
+                        Math.min(this.fragment_index + 1, this.fragments.size() - 1),
+                        Math.min(this.fragment_index + forecastSize, this.fragments.size()))
+                .stream()
                 .mapToDouble(CarbonFragment::getCarbonIntensity)
                 .toArray();
     }


### PR DESCRIPTION
## Summary

Fixed a small problem with getForeCast. 
When the simulation ran longer than the Carbon Trace, it crashed because it went out of bounds. 
The new version will keep returning a list of the last Carbon Intensity measurement in the trace.


## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*