### PR TITLE
Separate timeshift into an interface and add it to memorizing

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ComputeService.java
+++ b/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ComputeService.java
@@ -436,6 +436,7 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
             taskQueue.add(request);
         }
         tasksPending++;
+
         requestSchedulingCycle();
         return request;
     }
@@ -484,7 +485,6 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
                 iterator = taskQueue.iterator()) {
             final SchedulingResult result = scheduler.select(iterator);
             if (result.getResultType() == SchedulingResultType.EMPTY) {
-
                 break;
             }
             final HostView hv = result.getHost();

--- a/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ServiceTask.java
+++ b/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ServiceTask.java
@@ -251,7 +251,10 @@ public class ServiceTask {
             this.numPauses++;
         }
 
-        if ((newState == TaskState.COMPLETED) || newState == TaskState.FAILED) {
+        if ((newState == TaskState.COMPLETED)
+            || (newState == TaskState.FAILED)
+            || (newState == TaskState.TERMINATED)
+        ) {
             this.finishedAt = this.service.getClock().instant();
         }
 

--- a/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ServiceTask.java
+++ b/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ServiceTask.java
@@ -251,10 +251,7 @@ public class ServiceTask {
             this.numPauses++;
         }
 
-        if ((newState == TaskState.COMPLETED)
-            || (newState == TaskState.FAILED)
-            || (newState == TaskState.TERMINATED)
-        ) {
+        if ((newState == TaskState.COMPLETED) || (newState == TaskState.FAILED) || (newState == TaskState.TERMINATED)) {
             this.finishedAt = this.service.getClock().instant();
         }
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/ComputeSchedulers.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/ComputeSchedulers.kt
@@ -120,7 +120,6 @@ public fun createPrefabComputeScheduler(
         ComputeSchedulerEnum.TaskNumMemorizing ->
             MemorizingScheduler(
                 filters = listOf(ComputeFilter(), VCpuFilter(cpuAllocationRatio), RamFilter(ramAllocationRatio)),
-                random = SplittableRandom(seeder.nextLong()),
             )
         ComputeSchedulerEnum.Timeshift ->
             TimeshiftScheduler(

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
@@ -25,8 +25,6 @@ package org.opendc.compute.simulator.scheduler
 import org.opendc.compute.simulator.scheduler.filters.HostFilter
 import org.opendc.compute.simulator.service.HostView
 import org.opendc.compute.simulator.service.ServiceTask
-import java.util.SplittableRandom
-import java.util.random.RandomGenerator
 
 /*
 This scheduler records the number of tasks scheduled on each host.

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
@@ -78,6 +78,9 @@ public class MemorizingScheduler(
             return SchedulingResult(SchedulingResultType.FAILURE)
         }
 
+        val maxIters = 10000
+        var numIters = 0
+
         var chosenList: MutableList<HostView>? = null
         var chosenHost: HostView? = null
 
@@ -86,6 +89,11 @@ public class MemorizingScheduler(
             if (req.isCancelled) {
                 iter.remove()
                 continue
+            }
+
+            numIters++
+            if (numIters > maxIters) {
+                return SchedulingResult(SchedulingResultType.EMPTY)
             }
 
             for (chosenListIndex in minAvailableHost until hostsQueue.size) {

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/MemorizingTimeshift.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/MemorizingTimeshift.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2025 AtLarge Research
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.opendc.compute.simulator.scheduler.timeshift
 
 import org.opendc.compute.simulator.scheduler.ComputeScheduler
@@ -92,9 +114,9 @@ public class MemorizingTimeshift(
             val task = req.task
 
             /**
-            If we are not in a low carbon regime, delay tasks.
-            Only delay tasks if they are deferrable and it doesn't violate the deadline.
-            Separate delay thresholds for short and long tasks.
+             If we are not in a low carbon regime, delay tasks.
+             Only delay tasks if they are deferrable and it doesn't violate the deadline.
+             Separate delay thresholds for short and long tasks.
              */
             if (task.nature.deferrable) {
                 val durInHours = task.duration.toHours()

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/MemorizingTimeshift.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/MemorizingTimeshift.kt
@@ -1,47 +1,38 @@
-/*
- * Copyright (c) 2024 AtLarge Research
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- */
+package org.opendc.compute.simulator.scheduler.timeshift
 
-package org.opendc.compute.simulator.scheduler
-
+import org.opendc.compute.simulator.scheduler.ComputeScheduler
+import org.opendc.compute.simulator.scheduler.SchedulingRequest
+import org.opendc.compute.simulator.scheduler.SchedulingResult
+import org.opendc.compute.simulator.scheduler.SchedulingResultType
 import org.opendc.compute.simulator.scheduler.filters.HostFilter
 import org.opendc.compute.simulator.service.HostView
 import org.opendc.compute.simulator.service.ServiceTask
-import java.util.SplittableRandom
-import java.util.random.RandomGenerator
+import org.opendc.simulator.compute.power.CarbonModel
+import java.time.Instant
+import java.time.InstantSource
+import java.util.LinkedList
 
-/*
-This scheduler records the number of tasks scheduled on each host.
-When scheduling a new task, it assign the next task to the host with the least number of tasks.
-We filter hosts to check if the specific task can actually run on the host.
- */
-public class MemorizingScheduler(
+public class MemorizingTimeshift(
     private val filters: List<HostFilter>,
-    private val maxTimesSkipped: Int = 7,
-) : ComputeScheduler {
+    override val windowSize: Int,
+    override val clock: InstantSource,
+    override val forecast: Boolean = true,
+    override val shortForecastThreshold: Double = 0.2,
+    override val longForecastThreshold: Double = 0.35,
+    override val forecastSize: Int = 24,
+    public val maxTimesSkipped: Int = 7,
+) : ComputeScheduler, Timeshifter {
     // We assume that there will be max 200 tasks per host.
     // The index of a host list is the number of tasks on that host.
-    private val hostsQueue = List(100, { mutableListOf<HostView>() })
+    private val hostsQueue = List(100) { mutableListOf<HostView>() }
     private var minAvailableHost = 0
     private var numHosts = 0
+
+    override val pastCarbonIntensities: LinkedList<Double> = LinkedList<Double>()
+    override var carbonRunningSum: Double = 0.0
+    override var shortLowCarbon: Boolean = false // Low carbon regime for short tasks (< 2 hours)
+    override var longLowCarbon: Boolean = false // Low carbon regime for long tasks (>= hours)
+    override var carbonMod: CarbonModel? = null
 
     override fun addHost(host: HostView) {
         val zeroQueue = hostsQueue[0]
@@ -80,6 +71,9 @@ public class MemorizingScheduler(
             return SchedulingResult(SchedulingResultType.FAILURE)
         }
 
+        val maxIters = 10000
+        var numIters = 0
+
         var chosenList: MutableList<HostView>? = null
         var chosenHost: HostView? = null
 
@@ -88,6 +82,33 @@ public class MemorizingScheduler(
             if (req.isCancelled) {
                 iter.remove()
                 continue
+            }
+
+            numIters++
+            if (numIters > maxIters) {
+                return SchedulingResult(SchedulingResultType.EMPTY)
+            }
+
+            val task = req.task
+
+            /**
+            If we are not in a low carbon regime, delay tasks.
+            Only delay tasks if they are deferrable and it doesn't violate the deadline.
+            Separate delay thresholds for short and long tasks.
+             */
+            if (task.nature.deferrable) {
+                val durInHours = task.duration.toHours()
+                if ((durInHours < 2 && !shortLowCarbon) ||
+                    (durInHours >= 2 && !longLowCarbon)
+                ) {
+                    val currentTime = clock.instant()
+                    val estimatedCompletion = currentTime.plus(task.duration)
+                    val deadline = Instant.ofEpochMilli(task.deadline)
+                    if (estimatedCompletion.isBefore(deadline)) {
+                        // No need to schedule this task in a high carbon intensity period
+                        continue
+                    }
+                }
             }
 
             for (chosenListIndex in minAvailableHost until hostsQueue.size) {

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/Timeshifter.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/Timeshifter.kt
@@ -1,0 +1,74 @@
+package org.opendc.compute.simulator.scheduler.timeshift
+
+import org.opendc.simulator.compute.power.CarbonModel
+import org.opendc.simulator.compute.power.CarbonReceiver
+import java.time.InstantSource
+import java.util.LinkedList
+import kotlin.math.roundToInt
+
+public interface Timeshifter: CarbonReceiver {
+    public val windowSize: Int
+    public val clock: InstantSource
+    public val forecast: Boolean
+    public val shortForecastThreshold: Double
+    public val longForecastThreshold: Double
+    public val forecastSize: Int
+
+    public val pastCarbonIntensities: LinkedList<Double>
+    public var carbonRunningSum: Double
+    public var shortLowCarbon: Boolean // Low carbon regime for short tasks (< 2 hours)
+    public var longLowCarbon: Boolean // Low carbon regime for long tasks (>= hours)
+    public var carbonMod: CarbonModel?
+
+    /**
+    Compare current carbon intensity to the chosen quantile from the [forecastSize]
+    number of intensity forecasts
+     */
+    override fun updateCarbonIntensity(newCarbonIntensity: Double) {
+        if (!forecast) {
+            noForecastUpdateCarbonIntensity(newCarbonIntensity)
+            return
+        }
+
+        val forecast = carbonMod!!.getForecast(forecastSize)
+        val localForecastSize = forecast.size
+
+        val shortQuantileIndex = (localForecastSize * shortForecastThreshold).roundToInt()
+        val shortCarbonIntensity = forecast.sorted()[shortQuantileIndex]
+        val longQuantileIndex = (localForecastSize * longForecastThreshold).roundToInt()
+        val longCarbonIntensity = forecast.sorted()[longQuantileIndex]
+
+        shortLowCarbon = newCarbonIntensity < shortCarbonIntensity
+        longLowCarbon = newCarbonIntensity < longCarbonIntensity
+    }
+
+    /**
+    Compare current carbon intensity to the moving average of the past [windowSize]
+    number of intensity updates
+     */
+    private fun noForecastUpdateCarbonIntensity(newCarbonIntensity: Double) {
+        val previousCarbonIntensity =
+            if (this.pastCarbonIntensities.isEmpty()) {
+                0.0
+            } else {
+                this.pastCarbonIntensities.last()
+            }
+        this.pastCarbonIntensities.addLast(newCarbonIntensity)
+        this.carbonRunningSum += newCarbonIntensity
+        if (this.pastCarbonIntensities.size > this.windowSize) {
+            this.carbonRunningSum -= this.pastCarbonIntensities.removeFirst()
+        }
+
+        val thresholdCarbonIntensity = this.carbonRunningSum / this.pastCarbonIntensities.size
+
+        shortLowCarbon = (newCarbonIntensity < thresholdCarbonIntensity) &&
+            (newCarbonIntensity > previousCarbonIntensity)
+        longLowCarbon = (newCarbonIntensity < thresholdCarbonIntensity)
+    }
+
+    override fun setCarbonModel(carbonModel: CarbonModel?) {
+        this.carbonMod = carbonModel
+    }
+
+    override fun removeCarbonModel(carbonModel: CarbonModel?) {}
+}

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/Timeshifter.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/Timeshifter.kt
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2025 AtLarge Research
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package org.opendc.compute.simulator.scheduler.timeshift
 
 import org.opendc.simulator.compute.power.CarbonModel
@@ -6,7 +28,7 @@ import java.time.InstantSource
 import java.util.LinkedList
 import kotlin.math.roundToInt
 
-public interface Timeshifter: CarbonReceiver {
+public interface Timeshifter : CarbonReceiver {
     public val windowSize: Int
     public val clock: InstantSource
     public val forecast: Boolean
@@ -21,8 +43,8 @@ public interface Timeshifter: CarbonReceiver {
     public var carbonMod: CarbonModel?
 
     /**
-    Compare current carbon intensity to the chosen quantile from the [forecastSize]
-    number of intensity forecasts
+     Compare current carbon intensity to the chosen quantile from the [forecastSize]
+     number of intensity forecasts
      */
     override fun updateCarbonIntensity(newCarbonIntensity: Double) {
         if (!forecast) {
@@ -43,8 +65,8 @@ public interface Timeshifter: CarbonReceiver {
     }
 
     /**
-    Compare current carbon intensity to the moving average of the past [windowSize]
-    number of intensity updates
+     Compare current carbon intensity to the moving average of the past [windowSize]
+     number of intensity updates
      */
     private fun noForecastUpdateCarbonIntensity(newCarbonIntensity: Double) {
         val previousCarbonIntensity =

--- a/opendc-compute/opendc-compute-simulator/src/test/kotlin/org/opendc/compute/simulator/scheduler/MemorizingSchedulerTest.kt
+++ b/opendc-compute/opendc-compute-simulator/src/test/kotlin/org/opendc/compute/simulator/scheduler/MemorizingSchedulerTest.kt
@@ -33,8 +33,6 @@ import org.opendc.compute.simulator.host.HostModel
 import org.opendc.compute.simulator.host.HostState
 import org.opendc.compute.simulator.scheduler.filters.RamFilter
 import org.opendc.compute.simulator.service.HostView
-import java.util.Random
-import java.util.random.RandomGenerator
 
 internal class MemorizingSchedulerTest {
     @Test
@@ -57,7 +55,6 @@ internal class MemorizingSchedulerTest {
         val scheduler =
             MemorizingScheduler(
                 filters = emptyList(),
-                random = Random(1),
             )
 
         val hostA = mockk<HostView>()
@@ -84,15 +81,11 @@ internal class MemorizingSchedulerTest {
     @Test
     fun testRamFilter() {
         // Make Random with predictable order of numbers to test max skipped logic
-        val r = mockk<RandomGenerator>()
         val scheduler =
             MemorizingScheduler(
                 filters = listOf(RamFilter(1.0)),
-                random = r,
                 maxTimesSkipped = 3,
             )
-
-        every { r.nextInt(any()) } returns 0
 
         val hostA = mockk<HostView>()
         every { hostA.host.getState() } returns HostState.UP

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/allocation/AllocationPolicySpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/allocation/AllocationPolicySpec.kt
@@ -88,8 +88,15 @@ public fun createComputeScheduler(
             val filters = spec.filters.map { createHostFilter(it) }
             val weighers = spec.weighers.map { createHostWeigher(it) }
             if (spec.memorize) {
-                MemorizingTimeshift(filters, spec.windowSize, clock, spec.forecast,
-                    spec.shortForecastThreshold, spec.longForecastThreshold, spec.forecastSize,)
+                MemorizingTimeshift(
+                    filters,
+                    spec.windowSize,
+                    clock,
+                    spec.forecast,
+                    spec.shortForecastThreshold,
+                    spec.longForecastThreshold,
+                    spec.forecastSize,
+                )
             } else {
                 TimeshiftScheduler(
                     filters, weighers, spec.windowSize, clock, spec.subsetSize, spec.forecast,

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/allocation/AllocationPolicySpec.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/specs/allocation/AllocationPolicySpec.kt
@@ -28,6 +28,7 @@ import org.opendc.compute.simulator.scheduler.ComputeScheduler
 import org.opendc.compute.simulator.scheduler.ComputeSchedulerEnum
 import org.opendc.compute.simulator.scheduler.FilterScheduler
 import org.opendc.compute.simulator.scheduler.createPrefabComputeScheduler
+import org.opendc.compute.simulator.scheduler.timeshift.MemorizingTimeshift
 import org.opendc.compute.simulator.scheduler.timeshift.TaskStopper
 import org.opendc.compute.simulator.scheduler.timeshift.TimeshiftScheduler
 import java.time.InstantSource
@@ -68,6 +69,7 @@ public data class TimeShiftAllocationPolicySpec(
     val longForecastThreshold: Double = 0.35,
     val forecastSize: Int = 24,
     val taskStopper: TaskStopperSpec? = null,
+    val memorize: Boolean = true,
 ) : AllocationPolicySpec
 
 public fun createComputeScheduler(
@@ -85,10 +87,15 @@ public fun createComputeScheduler(
         is TimeShiftAllocationPolicySpec -> {
             val filters = spec.filters.map { createHostFilter(it) }
             val weighers = spec.weighers.map { createHostWeigher(it) }
-            TimeshiftScheduler(
-                filters, weighers, spec.windowSize, clock, spec.subsetSize, spec.forecast,
-                spec.shortForecastThreshold, spec.longForecastThreshold, spec.forecastSize, seeder,
-            )
+            if (spec.memorize) {
+                MemorizingTimeshift(filters, spec.windowSize, clock, spec.forecast,
+                    spec.shortForecastThreshold, spec.longForecastThreshold, spec.forecastSize,)
+            } else {
+                TimeshiftScheduler(
+                    filters, weighers, spec.windowSize, clock, spec.subsetSize, spec.forecast,
+                    spec.shortForecastThreshold, spec.longForecastThreshold, spec.forecastSize, seeder,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Add timeshift ability to memorizing scheduler. Separate timeshift into a separate interface so that it can be added to any scheduler.

## Implementation Notes :hammer_and_pick:

Add a max 10,000 iteration limit to timeshift memorizing

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*