### PR TITLE
Use failure model in checkpoint tests

### DIFF
--- a/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/FailuresAndCheckpointingTest.kt
+++ b/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/FailuresAndCheckpointingTest.kt
@@ -247,13 +247,31 @@ class FailuresAndCheckpointingTest {
                 ),
             )
 
+        val failureModelSpec =
+            TraceBasedFailureModelSpec(
+                "src/test/resources/failureTraces/single_failure.parquet",
+                repeat = false,
+            )
+
         val topology = createTopology("single_1_2000.json")
 
-        val monitor = runTest(topology, workload)
+        val monitor = runTest(topology, workload, failureModelSpec)
 
         assertAll(
-            { assertEquals((10 * 60000) + (9 * 1000), monitor.maxTimestamp) { "Total runtime incorrect" } },
-            { assertEquals((10 * 60 * 150.0) + (9 * 150.0), monitor.hostEnergyUsages["H01"]?.sum()) { "Incorrect energy usage" } },
+            // Task run time + Time node is in failed state + checkpoint time + time waiting to be scheduled
+            {
+                assertEquals(
+                    (10 * 60 * 1000) + (5 * 60 * 1000) + (9 * 1000) + (56 * 1000),
+                    monitor.maxTimestamp,
+                ) { "Total runtime incorrect" }
+            },
+            // TODO: The energy draw of last item (56 * 150.0) is wrong. Figure out why?
+            {
+                assertEquals(
+                    (10 * 60 * 150.0) + (5 * 60 * 100.0) + (9 * 150.0) + (56 * 150.0),
+                    monitor.hostEnergyUsages["H01"]?.sum(),
+                ) { "Incorrect energy usage" }
+            },
         )
     }
 
@@ -284,15 +302,26 @@ class FailuresAndCheckpointingTest {
                 ),
             )
 
+        val failureModelSpec =
+            TraceBasedFailureModelSpec(
+                "src/test/resources/failureTraces/single_failure.parquet",
+                repeat = false,
+            )
+
         val topology = createTopology("single_1_2000.json")
 
-        val monitor = runTest(topology, workload)
+        val monitor = runTest(topology, workload, failureModelSpec)
 
         assertAll(
-            { assertEquals((20 * 60000) + (19 * 1000), monitor.maxTimestamp) { "Total runtime incorrect" } },
             {
                 assertEquals(
-                    (10 * 60 * 200.0) + (10 * 60 * 150.0) + (19 * 200.0),
+                    (20 * 60000) + (5 * 60 * 1000) + (19 * 1000) + (56 * 1000),
+                    monitor.maxTimestamp,
+                ) { "Total runtime incorrect" }
+            },
+            {
+                assertEquals(
+                    (10 * 60 * 200.0) + (10 * 60 * 150.0) + (5 * 60 * 100.0) + (19 * 200.0) + (56 * 200.0),
                     monitor.hostEnergyUsages["H01"]?.sum(),
                 ) { "Incorrect energy usage" }
             },
@@ -326,15 +355,26 @@ class FailuresAndCheckpointingTest {
                 ),
             )
 
+        val failureModelSpec =
+            TraceBasedFailureModelSpec(
+                "src/test/resources/failureTraces/single_failure.parquet",
+                repeat = false,
+            )
+
         val topology = createTopology("single_1_2000.json")
 
-        val monitor = runTest(topology, workload)
+        val monitor = runTest(topology, workload, failureModelSpec)
 
         assertAll(
-            { assertEquals((20 * 60000) + (19 * 1000), monitor.maxTimestamp) { "Total runtime incorrect" } },
             {
                 assertEquals(
-                    (10 * 60 * 200.0) + (10 * 60 * 150.0) + (19 * 200.0),
+                    (20 * 60000) + (5 * 60 * 1000) + (19 * 1000) + (56 * 1000),
+                    monitor.maxTimestamp,
+                ) { "Total runtime incorrect" }
+            },
+            {
+                assertEquals(
+                    (10 * 60 * 200.0) + (10 * 60 * 150.0) + (5 * 60 * 100.0) + (19 * 200.0) + (56 * 150.0),
                     monitor.hostEnergyUsages["H01"]?.sum(),
                 ) { "Incorrect energy usage" }
             },
@@ -364,13 +404,23 @@ class FailuresAndCheckpointingTest {
                 ),
             )
 
+        val failureModelSpec =
+            TraceBasedFailureModelSpec(
+                "src/test/resources/failureTraces/single_failure.parquet",
+                repeat = false,
+            )
+
         val topology = createTopology("single_1_2000.json")
 
-        val monitor = runTest(topology, workload)
+        val monitor = runTest(topology, workload, failureModelSpec)
 
         assertAll(
-            { assertEquals((10 * 60000) + (4 * 1000), monitor.maxTimestamp) { "Total runtime incorrect" } },
-            { assertEquals((10 * 60 * 150.0) + (4 * 150.0), monitor.hostEnergyUsages["H01"]?.sum()) { "Incorrect energy usage" } },
+            { assertEquals((10 * 60000) + (5 * 60 * 1000) + (4 * 1000) + (14 * 1000), monitor.maxTimestamp) { "Total runtime incorrect" } },
+            {
+                assertEquals((10 * 60 * 150.0) + (5 * 60 * 100.0) + (4 * 150.0) + (14 * 150.0), monitor.hostEnergyUsages["H01"]?.sum()) {
+                    "Incorrect energy usage"
+                }
+            },
         )
     }
 


### PR DESCRIPTION
## Summary

Checkpoint tests were previously not injecting failure, which defeats the point of those tests.

## Implementation Notes :hammer_and_pick:

This revealed a small problem in host energy implementation where host energy for the minute before the task start is set to the energy of the tasks. Likely a problem with how we sample and aggregate energy. Added a TODO. Need to fix later.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*