### PR TITLE
Fixed bug when not providing a Carbon Model

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/ServiceRegistry.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/ServiceRegistry.kt
@@ -32,8 +32,29 @@ public class ServiceRegistry(private val registry: MutableMap<String, MutableMap
     ): T? {
         val servicesForName = registry[name] ?: return null
 
-        @Suppress("UNCHECKED_CAST")
-        return servicesForName[type] as T?
+        val service = servicesForName[type]
+
+        if (service == null) {
+            throw IllegalStateException("Service $type not registered for name $name")
+        }
+
+        try {
+            @Suppress("UNCHECKED_CAST")
+            return service as T?
+        } catch (e: ClassCastException) {
+            throw IllegalStateException("Service $type registered for name $name is not of the given type")
+        }
+    }
+
+    public fun <T : Any> hasService(
+        name: String,
+        type: Class<T>,
+    ): Boolean {
+        val servicesForName = registry[name] ?: return false
+
+        servicesForName[type] ?: return false
+
+        return true
     }
 
     public fun <T : Any> register(

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltTaskExportColumns.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltTaskExportColumns.kt
@@ -80,7 +80,12 @@ public object DfltTaskExportColumns {
                 Types.required(BINARY)
                     .`as`(LogicalTypeAnnotation.stringType())
                     .named("host_name"),
-        ) { Binary.fromString(it.host?.name) }
+        ) {
+            if (it.hostInfo == null) {
+                return@ExportColumn Binary.fromString("")
+            }
+            return@ExportColumn Binary.fromString(it.hostInfo!!.name)
+        }
 
     public val MEM_CAPACITY: ExportColumn<TaskTableReader> =
         ExportColumn(
@@ -168,7 +173,12 @@ public object DfltTaskExportColumns {
                 Types.optional(BINARY)
                     .`as`(LogicalTypeAnnotation.stringType())
                     .named("task_state"),
-        ) { Binary.fromString(it.taskState?.name) }
+        ) {
+            if (it.taskState == null) {
+                return@ExportColumn Binary.fromString("")
+            }
+            return@ExportColumn Binary.fromString(it.taskState!!.name)
+        }
 
     /**
      * The columns that are always included in the output file.

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReader.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReader.kt
@@ -58,7 +58,7 @@ public interface TaskTableReader : Exportable {
     /**
      * The [HostInfo] of the host on which the task is hosted or `null` if it has no host.
      */
-    public val host: HostInfo?
+    public val hostInfo: HostInfo?
 
     /**
      * The uptime of the host since last time in ms.

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReaderImpl.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReaderImpl.kt
@@ -50,7 +50,7 @@ public class TaskTableReaderImpl(
     }
 
     override fun setValues(table: TaskTableReader) {
-        host = table.host
+        hostInfo = table.hostInfo
 
         _timestamp = table.timestamp
         _timestampAbsolute = table.timestampAbsolute
@@ -90,8 +90,8 @@ public class TaskTableReaderImpl(
     /**
      * The [HostInfo] of the host on which the task is hosted.
      */
-    override var host: HostInfo? = null
-    private var _host: SimHost? = null
+    override var hostInfo: HostInfo? = null
+    private var simHost: SimHost? = null
 
     private var _timestamp = Instant.MIN
     override val timestamp: Instant
@@ -172,9 +172,9 @@ public class TaskTableReaderImpl(
      */
     override fun record(now: Instant) {
         val newHost = service.lookupHost(task)
-        if (newHost != null && newHost.getName() != _host?.getName()) {
-            _host = newHost
-            host =
+        if (newHost != null && newHost.getName() != simHost?.getName()) {
+            simHost = newHost
+            hostInfo =
                 HostInfo(
                     newHost.getName(),
                     newHost.getClusterName(),
@@ -185,8 +185,8 @@ public class TaskTableReaderImpl(
                 )
         }
 
-        val cpuStats = _host?.getCpuStats(task)
-        val sysStats = _host?.getSystemStats(task)
+        val cpuStats = simHost?.getCpuStats(task)
+        val sysStats = simHost?.getSystemStats(task)
 
         _timestamp = now
         _timestampAbsolute = now + startTime
@@ -221,7 +221,7 @@ public class TaskTableReaderImpl(
         previousCpuStealTime = _cpuStealTime
         previousCpuLostTime = _cpuLostTime
 
-        _host = null
+        simHost = null
         _cpuLimit = 0.0
     }
 }

--- a/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ExperimentRunnerTest.kt
+++ b/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ExperimentRunnerTest.kt
@@ -24,23 +24,24 @@ package org.opendc.experiments.base
 
 import org.junit.jupiter.api.Test
 import org.opendc.experiments.base.runner.ExperimentCommand
+import java.io.File
 
 /**
- * An integration test suite for the Scenario experiments.
+ * An integration test suite for the Experiment Runner.
  */
 class ExperimentRunnerTest {
     /**
-     * Simulator test 1: Single Task
-     * In this test, a single task is scheduled that takes 10 minutes to run.
+     * ExperimentRunner test 1
+     * This test runs the experiment defined in the experiment_1.json file.
      *
-     * There should be no problems running the task, so the total runtime should be 10 min.
-     *
-     * The task is using 50% of the available CPU capacity.
-     * This means that half of the time is active, and half is idle.
-     * When the task is failed, all time is idle.
+     * In this test, the bitbrains-small workload is executed with and without a carbon trace.
      */
     @Test
     fun testExperimentRunner1() {
         ExperimentCommand().main(arrayOf("--experiment-path", "src/test/resources/experiments/experiment_1.json"))
+
+
+        val someDir = File("output")
+        someDir.deleteRecursively()
     }
 }

--- a/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ExperimentRunnerTest.kt
+++ b/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ExperimentRunnerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 AtLarge Research
+ * Copyright (c) 2020 AtLarge Research
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,35 +20,27 @@
  * SOFTWARE.
  */
 
-@file:JvmName("ExperimentCli")
+package org.opendc.experiments.base
 
-package org.opendc.experiments.base.runner
-
-import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.parameters.options.defaultLazy
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.types.file
-import org.opendc.experiments.base.experiment.getExperiment
-import java.io.File
+import org.junit.jupiter.api.Test
+import org.opendc.experiments.base.runner.ExperimentCommand
 
 /**
- * Main entrypoint of the application.
+ * An integration test suite for the Scenario experiments.
  */
-public fun main(args: Array<String>): Unit = ExperimentCommand().main(args)
-
-/**
- * Represents the command for the Scenario experiments.
- */
-internal class ExperimentCommand : CliktCommand(name = "experiment") {
+class ExperimentRunnerTest {
     /**
-     * The path to the environment directory.
+     * Simulator test 1: Single Task
+     * In this test, a single task is scheduled that takes 10 minutes to run.
+     *
+     * There should be no problems running the task, so the total runtime should be 10 min.
+     *
+     * The task is using 50% of the available CPU capacity.
+     * This means that half of the time is active, and half is idle.
+     * When the task is failed, all time is idle.
      */
-    private val experimentPath by option("--experiment-path", help = "path to experiment file")
-        .file(canBeDir = false, canBeFile = true)
-        .defaultLazy { File("resources/experiment.json") }
-
-    override fun run() {
-        val experiment = getExperiment(experimentPath)
-        runExperiment(experiment)
+    @Test
+    fun testExperimentRunner1() {
+        ExperimentCommand().main(arrayOf("--experiment-path", "src/test/resources/experiments/experiment_1.json"))
     }
 }

--- a/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ExperimentRunnerTest.kt
+++ b/opendc-experiments/opendc-experiments-base/src/test/kotlin/org/opendc/experiments/base/ExperimentRunnerTest.kt
@@ -40,7 +40,6 @@ class ExperimentRunnerTest {
     fun testExperimentRunner1() {
         ExperimentCommand().main(arrayOf("--experiment-path", "src/test/resources/experiments/experiment_1.json"))
 
-
         val someDir = File("output")
         someDir.deleteRecursively()
     }

--- a/opendc-experiments/opendc-experiments-base/src/test/resources/experiments/experiment_1.json
+++ b/opendc-experiments/opendc-experiments-base/src/test/resources/experiments/experiment_1.json
@@ -1,0 +1,23 @@
+{
+    "topologies": [
+        {"pathToFile": "src/test/resources/topologies/single_50_big.json"},
+        {"pathToFile": "src/test/resources/topologies/single_50_big_BE.json"}
+    ],
+    "workloads": [{
+        "pathToFile": "src/test/resources/workloadTraces/bitbrains-small",
+        "type": "ComputeWorkload",
+        "submissionTime": "2024-03-01T00:00:00"
+    }],
+    "allocationPolicies": [
+        {
+            "type": "prefab",
+            "policyName": "Mem"
+        }
+    ],
+    "exportModels": [
+        {
+            "exportInterval": 3600,
+            "printFrequency": 24
+        }
+    ]
+}

--- a/opendc-experiments/opendc-experiments-base/src/test/resources/topologies/single_50_big.json
+++ b/opendc-experiments/opendc-experiments-base/src/test/resources/topologies/single_50_big.json
@@ -1,0 +1,28 @@
+{
+    "clusters":
+    [
+        {
+            "name": "C01",
+            "hosts" :
+            [
+                {
+                    "name": "H01",
+                    "cpu":
+                    {
+                        "coreCount": 64,
+                        "coreSpeed": 2000
+                    },
+                    "memory": {
+                        "memorySize": 140457600000
+                    },
+                    "powerModel": {
+                        "modelType": "linear",
+                        "power": 400.0,
+                        "idlePower": 100.0,
+                        "maxPower": 200.0
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/opendc-experiments/opendc-experiments-base/src/test/resources/topologies/single_50_big_BE.json
+++ b/opendc-experiments/opendc-experiments-base/src/test/resources/topologies/single_50_big_BE.json
@@ -1,0 +1,31 @@
+{
+    "clusters":
+    [
+        {
+            "name": "C01",
+            "hosts" :
+            [
+                {
+                    "name": "H01",
+                    "cpu":
+                    {
+                        "coreCount": 64,
+                        "coreSpeed": 2000
+                    },
+                    "memory": {
+                        "memorySize": 140457600000
+                    },
+                    "powerModel": {
+                        "modelType": "linear",
+                        "power": 400.0,
+                        "idlePower": 100.0,
+                        "maxPower": 200.0
+                    }
+                }
+            ],
+            "powerSource": {
+                "carbonTracePath": "src/test/resources/carbonTraces/2022-01-01_2022-12-31_BE.parquet"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Fixed a bug in ScenarioRunner that made it impossible to use topologies that did not specify a CarbonTrace. 

The problem was caused by OpenDC trying to connect components to the CarbonModel, which did not exist. 

While fixing this issue, I have also made the following changes to the code: 
- A test that executes an experiment using ExperimentRunner was added. 
- Updated the ServiceResistry because it contained unsafe code.
- Updated the Exporters to handle null values from strings properly. 

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*