### PR TITLE
Fixed a problem with Tasks not showing the hostName after they are completed.

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ComputeService.java
+++ b/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ComputeService.java
@@ -205,7 +205,6 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
                     LOGGER.error("Unknown host {}", host);
                 }
 
-                task.setHost(null);
                 host.delete(task);
 
                 if (newState == TaskState.COMPLETED) {
@@ -523,7 +522,7 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
             LOGGER.info("Assigned task {} to host {}", task, host);
 
             try {
-                task.host = host;
+                task.setHost(host);
                 task.scheduledAt = clock.instant();
 
                 host.spawn(task);
@@ -709,7 +708,7 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
 
             //            from.delete(internalTask);
 
-            internalTask.host = null;
+            internalTask.setHost(null);
 
             internalTask.setWorkload(workload);
             internalTask.start();

--- a/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ServiceTask.java
+++ b/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ServiceTask.java
@@ -63,7 +63,9 @@ public class ServiceTask {
     Instant scheduledAt = null;
     Instant submittedAt;
     Instant finishedAt;
-    SimHost host = null;
+    private SimHost host = null;
+    private String hostName = null;
+
     private SchedulingRequest request = null;
 
     private int numFailures = 0;
@@ -158,8 +160,15 @@ public class ServiceTask {
         return host;
     }
 
-    public void setHost(SimHost host) {
-        this.host = host;
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHost(SimHost newHost) {
+        this.host = newHost;
+        if (newHost != null) {
+            this.hostName = newHost.getName();
+        }
     }
 
     public int getNumFailures() {

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltTaskExportColumns.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/parquet/DfltTaskExportColumns.kt
@@ -81,10 +81,10 @@ public object DfltTaskExportColumns {
                     .`as`(LogicalTypeAnnotation.stringType())
                     .named("host_name"),
         ) {
-            if (it.hostInfo == null) {
+            if (it.hostName == null) {
                 return@ExportColumn Binary.fromString("")
             }
-            return@ExportColumn Binary.fromString(it.hostInfo!!.name)
+            return@ExportColumn Binary.fromString(it.hostName)
         }
 
     public val MEM_CAPACITY: ExportColumn<TaskTableReader> =

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReader.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReader.kt
@@ -60,6 +60,8 @@ public interface TaskTableReader : Exportable {
      */
     public val hostInfo: HostInfo?
 
+    public val hostName: String?
+
     /**
      * The uptime of the host since last time in ms.
      */

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReaderImpl.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/telemetry/table/task/TaskTableReaderImpl.kt
@@ -52,6 +52,7 @@ public class TaskTableReaderImpl(
     override fun setValues(table: TaskTableReader) {
         hostInfo = table.hostInfo
 
+        _hostName = table.hostName
         _timestamp = table.timestamp
         _timestampAbsolute = table.timestampAbsolute
 
@@ -92,6 +93,10 @@ public class TaskTableReaderImpl(
      */
     override var hostInfo: HostInfo? = null
     private var simHost: SimHost? = null
+
+    private var _hostName: String? = null
+    override val hostName: String?
+        get() = _hostName
 
     private var _timestamp = Instant.MIN
     override val timestamp: Instant
@@ -187,6 +192,8 @@ public class TaskTableReaderImpl(
 
         val cpuStats = simHost?.getCpuStats(task)
         val sysStats = simHost?.getSystemStats(task)
+
+        _hostName = task.hostName
 
         _timestamp = now
         _timestampAbsolute = now + startTime


### PR DESCRIPTION
## Summary

Fixed a problem with Tasks not showing the hostName after they are completed.

Task now save the hostName of connected host, until a new Host is selected.

This is not a perfect fix, but I will improve on it later.

N / A 

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*