### PR TITLE
Adds Description of Virtualization Overhead modelling in OpenDC

### DIFF
--- a/site/docs/documentation/Input/Topology/DistributionPolicy.md
+++ b/site/docs/documentation/Input/Topology/DistributionPolicy.md
@@ -1,0 +1,83 @@
+The Distribution Policy is used to determine how resources are distributed at a host, across multiple Virtual Machines (VMs).
+OpenDC supports multiple distribution policies, describe as below, each extending a FlowDistributor class. 
+
+
+## Best Effort Distribution Policy
+
+The BestEffortFlowDistributor implements a sophisticated time-sliced round-robin approach designed to maximize resource utilization while maintaining reasonable fairness over time. 
+The distributor uses a configurable time interval to advance its round-robin index, ensuring that allocation priority rotates among consumers.
+It prioritizes already active suppliers to reduce activation overhead and implements a two-phase allocation strategy: first satisfying demands in round-robin order, then optimizing remaining capacity distribution.
+The update interval length parameter defines how long each round in the round-robin cycle lasts.
+This policy is heavily inspired by the best effort GPU scheduling policy used in NVIDIA's vGPU scheduler.
+
+Example
+``` json
+"gpuDistributionPolicy": {
+    "type": "BEST_EFFORT",
+    "updateIntervalLength": 60000
+}
+```
+
+## Equal Share Distribution Policy
+
+The EqualShareFlowDistributor implements the simplest distribution strategy by dividing total capacity equally among all consumers,
+completely ignoring individual demand levels. This distributor calculates a fixed equal share (totalSupply / numberOfConsumers) and allocates this amount to every consumer regardless of their actual needs.
+The algorithm is deterministic and predictable, making it ideal for scenarios where uniform resource access is more important than efficiency.
+This policy is heavily inspired by the equal share GPU scheduling policy used in NVIDIA's vGPU scheduler.
+
+Example:
+``` json
+"gpuDistributionPolicy": {
+  "type": "EQUAL_SHARE"
+}
+```
+
+## First Fit Distribution Policy
+This distributor allocates resources to consumers based on the first available supply that meets their demand.
+It does not attempt to balance loads or optimize resource usage beyond the first fit principle.
+It tries to place demands on already existing supplies before involving another supplier.
+It assumes that the resource can be partitioned, if one supplier cannot satisfy the demand, it will try to combine multiple suppliers.
+
+
+Example:
+``` json
+"gpuDistributionPolicy": {
+"type": "FIRST_FIT"
+}
+```
+
+## Fixed Share Distribution Policy
+
+This distributor allocates a dedicated, consistent portion of the requested resources to each VM (consumer), 
+ensuring predictable availability and stable performance. Each active consumer receives a fixed share of the total resource capacity, regardless of their individual demand or the demand of other consumers.
+Key characteristics:
+- Each consumer gets a fixed percentage of total resource capacity when active
+- Unused shares (from inactive consumers) remain unallocated, not redistributed
+- Performance remains consistent and predictable for each consumer
+- Share allocation is based on maximum supported consumers, not currently active ones  
+
+The share ratio is defined as a percentage of the total resource capacity, and it is applied uniformly across all active suppliers.
+This policy is heavily inspired by the fixed share GPU scheduling policy used in NVIDIA's vGPU scheduler.
+
+Example:
+``` json
+"gpuDistributionPolicy": {
+    "type": "FIXED_SHARE",
+    "shareRatio": 0.5
+}
+```
+
+## Max Min Fairness Distribution Policy
+
+The MaxMinFairnessFlowDistributor implements the max-min fairness algorithm,
+which prioritizes satisfying smaller demands first to ensure no consumer is completely starved of resources.
+The algorithm sorts consumers by their demand levels and allocates resources incrementally, ensuring that the minimum allocation received by any consumer is maximized. 
+It maintains an overload state to track when total demand exceeds available supply and applies different distribution strategies accordingly.
+**This is the default policy in OpenDC**.
+
+Example:
+``` json
+"gpuDistributionPolicy": {
+  "type": "MAX_MIN_FAIRNESS"
+}
+```

--- a/site/docs/documentation/Input/Topology/Host.md
+++ b/site/docs/documentation/Input/Topology/Host.md
@@ -36,17 +36,17 @@ A host is a machine that can execute tasks. A host consist of the following comp
 
 GPUS are an optional component of a host. The required fields are only required if the host has GPUs.
 
-| variable        | type    | Unit             | required? | default | description                                      |
-|-----------------|---------|------------------|-----------|---------|--------------------------------------------------|
-| modelName       | string  | N/A              | no        | unknown | The name of the GPU.                             |
-| vendor          | string  | N/A              | no        | unknown | The vendor of the GPU                            |
-| arch            | string  | N/A              | no        | unknown | the micro-architecture of the GPU                |
-| count           | integer | N/A              | no        | 1       | The number of GPUs of this type used by the host |
-| coreCount       | integer | count            | yes       | N/A     | The number of cores in the GPU                   |
-| coreSpeed       | Double  | Mhz              | yes       | N/A     | The speed of each core in Mhz                    |
-| memorySize      | integer | Byte             | no        | N/A     | The speed of each core in Mhz                    |
-| memoryBandwidth | Double  | Bytes per Second | no        | N/A     | The speed of each core in Mhz                    |
-
+| variable                     | type                                                                                          | Unit             | required? | default | description                                                            |
+|------------------------------|-----------------------------------------------------------------------------------------------|------------------|-----------|---------|------------------------------------------------------------------------|
+| modelName                    | string                                                                                        | N/A              | no        | unknown | The name of the GPU.                                                   |
+| vendor                       | string                                                                                        | N/A              | no        | unknown | The vendor of the GPU                                                  |
+| arch                         | string                                                                                        | N/A              | no        | unknown | the micro-architecture of the GPU                                      |
+| count                        | integer                                                                                       | N/A              | no        | 1       | The number of GPUs of this type used by the host                       |
+| coreCount                    | integer                                                                                       | count            | yes       | N/A     | The number of cores in the GPU                                         |
+| coreSpeed                    | Double                                                                                        | Mhz              | yes       | N/A     | The speed of each core in Mhz                                          |
+| memorySize                   | integer                                                                                       | Byte             | no        | N/A     | The speed of each core in Mhz                                          |
+| memoryBandwidth              | Double                                                                                        | Bytes per Second | no        | N/A     | The speed of each core in Mhz                                          |
+| virtualizationOverHeadModel  | [VirtualizationOverHeadModel](/docs/documentation/Input/Topology/VirtualizationOverHeadModel) | N/A              | no        | N/A     | The virtualization model of the GPU, used to determine the performance |
 
 ## Example - No GPU
 
@@ -101,7 +101,11 @@ For more information on the power model, see [Power Model](/docs/documentation/I
                     },
                     "gpu": {
                         "coreCount": 2,
-                        "coreSpeed": 2000
+                        "coreSpeed": 2000,
+                        "virtualizationOverHeadModel": {
+                            "type": "CONSTANT",
+                            "percentageOverhead": 0.25
+                        }
                     },
                     "gpuPowerModel": {
                         "modelType": "linear",

--- a/site/docs/documentation/Input/Topology/Host.md
+++ b/site/docs/documentation/Input/Topology/Host.md
@@ -1,12 +1,13 @@
 A host is a machine that can execute tasks. A host consist of the following components:
 
-| variable    | type                                                         | required? | default | description                                                                    |
-|-------------|:-------------------------------------------------------------|:----------|---------|--------------------------------------------------------------------------------|
-| name        | string                                                       | no        | Host    | The name of the host. This is only important for debugging and post-processing |
-| count       | integer                                                      | no        | 1       | The amount of hosts of this type are in the cluster                            |
-| cpuModel    | [CPU](#cpu)                                                  | yes       | N/A     | The CPUs in the host                                                           |
-| memory      | [Memory](#memory)                                            | yes       | N/A     | The memory used by the host                                                    |
-| power model | [Power Model](/docs/documentation/Input/Topology/PowerModel) | no        | Default | The power model used to determine the power draw of the host                   |
+| variable      | type                                                         | required? | default | description                                                                    |
+|---------------|:-------------------------------------------------------------|:----------|---------|--------------------------------------------------------------------------------|
+| name          | string                                                       | no        | Host    | The name of the host. This is only important for debugging and post-processing |
+| count         | integer                                                      | no        | 1       | The amount of hosts of this type are in the cluster                            |
+| cpuModel      | [CPU](#cpu)                                                  | yes       | N/A     | The CPUs in the host                                                           |
+| memory        | [Memory](#memory)                                            | yes       | N/A     | The memory used by the host                                                    |
+| cpuPowerModel | [Power Model](/docs/documentation/Input/Topology/PowerModel) | no        | Default | The power model used to determine the power draw of the cpu                    |
+| gpuPowerModel | [Power Model](/docs/documentation/Input/Topology/PowerModel) | no        | Default | The power model used to determine the power draw of the gpu                    |
 
 ## CPU
 

--- a/site/docs/documentation/Input/Topology/Host.md
+++ b/site/docs/documentation/Input/Topology/Host.md
@@ -1,13 +1,15 @@
 A host is a machine that can execute tasks. A host consist of the following components:
 
-| variable      | type                                                         | required? | default | description                                                                    |
-|---------------|:-------------------------------------------------------------|:----------|---------|--------------------------------------------------------------------------------|
-| name          | string                                                       | no        | Host    | The name of the host. This is only important for debugging and post-processing |
-| count         | integer                                                      | no        | 1       | The amount of hosts of this type are in the cluster                            |
-| cpuModel      | [CPU](#cpu)                                                  | yes       | N/A     | The CPUs in the host                                                           |
-| memory        | [Memory](#memory)                                            | yes       | N/A     | The memory used by the host                                                    |
-| cpuPowerModel | [Power Model](/docs/documentation/Input/Topology/PowerModel) | no        | Default | The power model used to determine the power draw of the cpu                    |
-| gpuPowerModel | [Power Model](/docs/documentation/Input/Topology/PowerModel) | no        | Default | The power model used to determine the power draw of the gpu                    |
+| variable              | type                                                                         | required? | default | description                                                                    |
+|-----------------------|:-----------------------------------------------------------------------------|:----------|---------|--------------------------------------------------------------------------------|
+| name                  | string                                                                       | no        | Host    | The name of the host. This is only important for debugging and post-processing |
+| count                 | integer                                                                      | no        | 1       | The amount of hosts of this type are in the cluster                            |
+| cpuModel              | [CPU](#cpu)                                                                  | yes       | N/A     | The CPUs in the host                                                           |
+| memory                | [Memory](#memory)                                                            | yes       | N/A     | The memory used by the host                                                    |
+| cpuPowerModel         | [Power Model](/docs/documentation/Input/Topology/PowerModel)                 | no        | Default | The power model used to determine the power draw of the cpu                    |
+| gpuPowerModel         | [Power Model](/docs/documentation/Input/Topology/PowerModel)                 | no        | Default | The power model used to determine the power draw of the gpu                    |
+| cpuDistributionPolicy | [Distribution Policy](/docs/documentation/Input/Topology/DistributionPolicy) | no        | Default | The distribution policy used for the CPU                                       |
+| gpuDistributionPolicy | [Distribution Policy](/docs/documentation/Input/Topology/DistributionPolicy) | no        | Default | The distribution policy used for the GPU                                       |
 
 ## CPU
 
@@ -94,6 +96,9 @@ For more information on the power model, see [Power Model](/docs/documentation/I
                         "idlePower": 100.0,
                         "maxPower": 200.0
                     },
+                    "cpuDistributionPolicy": {
+                        "type": "MAX_MIN_FAIRNESS"
+                    },
                     "gpu": {
                         "coreCount": 2,
                         "coreSpeed": 2000
@@ -103,6 +108,10 @@ For more information on the power model, see [Power Model](/docs/documentation/I
                         "power": 400.0,
                         "idlePower": 100.0,
                         "maxPower": 200.0
+                    },
+                    "gpuDistributionPolicy": {
+                        "type": "FIXED_SHARE",
+                        "shareRatio": 0.5
                     }
                 }
             ]

--- a/site/docs/documentation/Input/Topology/VirtualizationOverHeadModel.md
+++ b/site/docs/documentation/Input/Topology/VirtualizationOverHeadModel.md
@@ -1,0 +1,39 @@
+OpenDC offers to model the overhead of virtualization in a GPU. Overhead is modelled as decrease of supply.
+Three different models are available to represent the performance overhead of virtualization in a GPU as described below. 
+It is not required to define a virtualization overhead model for a GPU, in which case the GPU is assumed to be used directly by the VM without any overhead.
+
+
+## No Overhead
+
+This model assumes that there is no overhead when using a GPU.
+This type of overhead occurs when GPU pass-through or Para or Full virtualization is used.
+In this case, the GPU is used directly by the VM and there is no overhead.
+
+```` json
+"virtualizationOverHeadModel": {
+    "type": "NONE"
+}
+````
+
+## Constant Overhead
+
+The constant overhead model assumes that there is a fixed percentage of performance overhead when using a GPU. 
+The overhead can be customized by setting the `percentageOverhead` parameter.
+
+``` json
+"virtualizationOverHeadModel": {
+    "type": "CONSTANT",
+    "percentageOverhead": 0.25
+}
+```
+
+## Share Based Overhead
+
+The share based overhead model assumes that the performance overhead is based on the number of VMs sharing the GPU. 
+This is based on the insights of the paper by Garg et al. [Empirical Analysis of Hardware-Assisted GPU Virtualization](https://doi.org/10.1109/HiPC.2019.00054).
+
+``` json
+"virtualizationOverHeadModel": {
+    "type": "SHARE_BASED"
+}
+```

--- a/site/docs/documentation/Output.md
+++ b/site/docs/documentation/Output.md
@@ -44,43 +44,45 @@ The task output file, contains all metrics of related to the tasks that are bein
 | task_state         | String   | TaskState | The current state of the Task.                                              |
 
 ### Host
-The host output file, contains all metrics of related to the hosts that are running.
+The host output file, contains all metrics of related to the hosts that are running. 
+For each GPU attached to the host, there is a separate metric for each GPU. 
+The metrics are named `gpu_capacity_n`, `gpu_usage_n`, `gpu_demand_n`, etc., where `n` is the index of the GPU starting from 0.
 
-| Metric             | DataType | Unit       | Summary                                                                                             |
-|--------------------|----------|------------|-----------------------------------------------------------------------------------------------------|
-| timestamp          | int64    | ms         | Timestamp of the sample.                                                                            |
-| timestamp_absolute | int64    | ms         | The absolute timestamp based on the given workload.                                                 |
-| host_name          | binary   | string     | The name of the host.                                                                               |
-| cluster_name       | binary   | string     | The name of the cluster that this host is part of.                                                  |
-| cpu_count          | int32    | count      | The number of cores in this host.                                                                   |
-| mem_capacity       | int64    | Mb         | The amount of available memory.                                                                     |
-| tasks_terminated   | int32    | count      | The number of tasks that are in a terminated state.                                                 |
-| tasks_running      | int32    | count      | The number of tasks that are in a running state.                                                    |
-| tasks_error        | int32    | count      | The number of tasks that are in an error state.                                                     |
-| tasks_invalid      | int32    | count      | The number of tasks that are in an unknown state.                                                   |
-| cpu_capacity       | double   | MHz        | The total capacity of the CPUs in the host.                                                         |
-| cpu_usage          | double   | MHz        | The total CPU capacity provided to all tasks on this host.                                          |
-| cpu_demand         | double   | MHz        | The total CPU capacity demanded by all tasks on this host.                                          |
-| cpu_utilization    | double   | ratio      | The CPU utilization of the host. This is calculated by dividing the cpu_usage, by the cpu_capacity. |
-| cpu_time_active    | int64    | ms         | The duration that a CPU was active in the host.                                                     |
-| cpu_time_idle      | int64    | ms         | The duration that a CPU was idle in the host.                                                       |
-| cpu_time_steal     | int64    | ms         | The duration that a vCPU wanted to run, but no capacity was available.                              |
-| cpu_time_lost      | int64    | ms         | The duration of CPU time that was lost due to interference.                                         |
-| gpu_capacity       | double   | MHz        | The total capacity of the GPUs in the host.                                                         |
-| gpu_usage          | double   | MHz        | The total GPU capacity provided to all tasks on this host.                                          |
-| gpu_demand         | double   | MHz        | The total GPU capacity demanded by all tasks on this host.                                          |
-| gpu_utilization    | double   | ratio      | The GPU utilization of the host. This is calculated by dividing the gpu_usage, by the gpu_capacity. |
-| gpu_time_active    | int64    | ms         | The duration that a GPU was active in the host.                                                     |
-| gpu_time_idle      | int64    | ms         | The duration that a GPU was idle in the host.                                                       |
-| gpu_time_steal     | int64    | ms         | The duration that a vGPU wanted to run, but no capacity was available.                              |
-| gpu_time_lost      | int64    | ms         | The duration of GPU time that was lost due to interference.                                         |
-| power_draw         | double   | Watt       | The current power draw of the host.                                                                 |
-| energy_usage       | double   | Joule (Ws) | The total energy consumption of the host since last sample.                                         |
-| embodied_carbon    | double   | gram       | The total embodied carbon emitted since the last sample.                                            |
-| uptime             | int64    | ms         | The uptime of the host since last sample.                                                           |
-| downtime           | int64    | ms         | The downtime of the host since last sample.                                                         |
-| boot_time          | int64    | ms         | The time a host got booted.                                                                         |
-| boot_time_absolute | int64    | ms         | The absolute time a host got booted.                                                                |
+| Metric             | DataType | Unit       | Summary                                                                                                      |
+|--------------------|----------|------------|--------------------------------------------------------------------------------------------------------------|
+| timestamp          | int64    | ms         | Timestamp of the sample.                                                                                     |
+| timestamp_absolute | int64    | ms         | The absolute timestamp based on the given workload.                                                          |
+| host_name          | binary   | string     | The name of the host.                                                                                        |
+| cluster_name       | binary   | string     | The name of the cluster that this host is part of.                                                           |
+| cpu_count          | int32    | count      | The number of cores in this host.                                                                            |
+| mem_capacity       | int64    | Mb         | The amount of available memory.                                                                              |
+| tasks_terminated   | int32    | count      | The number of tasks that are in a terminated state.                                                          |
+| tasks_running      | int32    | count      | The number of tasks that are in a running state.                                                             |
+| tasks_error        | int32    | count      | The number of tasks that are in an error state.                                                              |
+| tasks_invalid      | int32    | count      | The number of tasks that are in an unknown state.                                                            |
+| cpu_capacity       | double   | MHz        | The total capacity of the CPUs in the host.                                                                  |
+| cpu_usage          | double   | MHz        | The total CPU capacity provided to all tasks on this host.                                                   |
+| cpu_demand         | double   | MHz        | The total CPU capacity demanded by all tasks on this host.                                                   |
+| cpu_utilization    | double   | ratio      | The CPU utilization of the host. This is calculated by dividing the cpu_usage, by the cpu_capacity.          |
+| cpu_time_active    | int64    | ms         | The duration that a CPU was active in the host.                                                              |
+| cpu_time_idle      | int64    | ms         | The duration that a CPU was idle in the host.                                                                |
+| cpu_time_steal     | int64    | ms         | The duration that a vCPU wanted to run, but no capacity was available.                                       |
+| cpu_time_lost      | int64    | ms         | The duration of CPU time that was lost due to interference.                                                  |
+| gpu_capacity_n     | double   | MHz        | The total capacity of the the n-th GPU in the host.                                                          |
+| gpu_usage_n        | double   | MHz        | The total of the n-th GPU capacity provided to all tasks on this host.                                       |
+| gpu_demand_n       | double   | MHz        | The total of the n-th GPU capacity demanded by all tasks on this host.                                       |
+| gpu_utilization_n  | double   | ratio      | The the n-th GPU utilization of the host. This is calculated by dividing the gpu_usage, by the gpu_capacity. |
+| gpu_time_active_n  | int64    | ms         | The duration that the n-th GPU was active in the host.                                                       |
+| gpu_time_idle_n    | int64    | ms         | The duration that the n-th GPU was idle in the host.                                                         |
+| gpu_time_steal_n   | int64    | ms         | The duration that the n-th vGPU wanted to run, but no capacity was available.                                |
+| gpu_time_lost_n    | int64    | ms         | The duration of the n-th GPU time that was lost due to interference.                                         |
+| power_draw         | double   | Watt       | The current power draw of the host.                                                                          |
+| energy_usage       | double   | Joule (Ws) | The total energy consumption of the host since last sample.                                                  |
+| embodied_carbon    | double   | gram       | The total embodied carbon emitted since the last sample.                                                     |
+| uptime             | int64    | ms         | The uptime of the host since last sample.                                                                    |
+| downtime           | int64    | ms         | The downtime of the host since last sample.                                                                  |
+| boot_time          | int64    | ms         | The time a host got booted.                                                                                  |
+| boot_time_absolute | int64    | ms         | The absolute time a host got booted.                                                                         |
 
 ### Power Source
 The power source output file, contains all metrics of related to the power sources.


### PR DESCRIPTION
** This PR depends on the [PR 354](https://github.com/atlarge-research/opendc/pull/354) and is related to [PR 357](https://github.com/atlarge-research/opendc/pull/357)**

## Summary

Adds the new field including description to the topology documentation. Further gives a brief explanation of the different virtualization modes.

## Implementation Notes :hammer_and_pick:

* Extension of Host.md
* new markdown file in topology folder for VirtualizationOverheadModel

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*