### PR TITLE
Updated FilterScheduler for performance

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ComputeService.java
+++ b/opendc-compute/opendc-compute-simulator/src/main/java/org/opendc/compute/simulator/service/ComputeService.java
@@ -193,6 +193,10 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
 
                 host.delete(task);
 
+                if (host.isEmpty()) {
+                    setHostEmpty(host);
+                }
+
                 if (newState == TaskState.COMPLETED) {
                     tasksCompleted++;
                     addCompletedTask(task);
@@ -292,6 +296,12 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
 
         scheduler.addHost(hv);
         host.addListener(hostListener);
+    }
+
+    public void setHostEmpty(SimHost host) {
+        HostView hv = hostToView.get(host);
+
+        this.scheduler.setHostEmpty(hv);
     }
 
     public void addPowerSource(SimPowerSource simPowerSource) {
@@ -437,11 +447,6 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
 
     void addCompletedTask(ServiceTask completedTask) {
         int parentId = completedTask.getId();
-        //        int taskId = task.getId();
-
-        //        if (!this.completedTasks.contains(taskId)) {
-        //            this.completedTasks.add(taskId);
-        //        }
 
         for (int taskId : completedTask.getFlavor().getChildren()) {
             SchedulingRequest request = blockedTasks.get(taskId);
@@ -457,24 +462,6 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
                 }
             }
         }
-
-        //        List<SchedulingRequest> requestsToRemove = new ArrayList<>();
-        //
-        //        for (SchedulingRequest request : blockedTasks) {
-        //            request.getTask().getFlavor().updatePendingDependencies(taskId);
-        //
-        //            Set<Integer> pendingDependencies = request.getTask().getFlavor().getDependencies();
-        //
-        //            if (pendingDependencies.isEmpty()) {
-        //                requestsToRemove.add(request);
-        //                taskQueue.add(request);
-        //                tasksPending++;
-        //            }
-        //        }
-        //
-        //        for (SchedulingRequest request : requestsToRemove) {
-        //            blockedTasks.remove(request);
-        //        }
     }
 
     void addTerminatedTask(ServiceTask task) {
@@ -493,25 +480,6 @@ public final class ComputeService implements AutoCloseable, CarbonReceiver {
                 blockedTasks.remove(childTask.getId());
             }
         }
-
-        //        int taskId = task.getId();
-        //
-        //        List<SchedulingRequest> requestsToRemove = new ArrayList<>();
-        //
-        //        if (!this.terminatedTasks.contains(taskId)) {
-        //            this.terminatedTasks.add(taskId);
-        //        }
-        //
-        //        for (SchedulingRequest request : blockedTasks) {
-        //            if (request.getTask().getFlavor().isInDependencies(taskId)) {
-        //                requestsToRemove.add(request);
-        //                request.getTask().setState(TaskState.TERMINATED);
-        //            }
-        //        }
-        //
-        //        for (SchedulingRequest request : requestsToRemove) {
-        //            blockedTasks.remove(request);
-        //        }
     }
 
     void delete(ServiceFlavor flavor) {

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/host/SimHost.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/host/SimHost.kt
@@ -56,6 +56,7 @@ import java.time.InstantSource
  */
 public class SimHost(
     private val name: String,
+    private val type: String,
     private val clusterName: String,
     private val clock: InstantSource,
     private val engine: FlowEngine,
@@ -201,6 +202,10 @@ public class SimHost(
         return name
     }
 
+    public fun getType(): String {
+        return type
+    }
+
     public fun getClusterName(): String {
         return clusterName
     }
@@ -215,6 +220,10 @@ public class SimHost(
 
     public fun getInstances(): Set<ServiceTask> {
         return taskToGuestMap.keys
+    }
+
+    public fun isEmpty(): Boolean {
+        return guests.isEmpty()
     }
 
     public fun getGuests(): List<Guest> {

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/HostsProvisioningStep.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/HostsProvisioningStep.kt
@@ -132,6 +132,7 @@ public class HostsProvisioningStep internal constructor(
                 val simHost =
                     SimHost(
                         hostSpec.name,
+                        hostSpec.type,
                         cluster.name,
                         ctx.dispatcher.timeSource,
                         engine,

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/ComputeScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/ComputeScheduler.kt
@@ -39,6 +39,8 @@ public interface ComputeScheduler {
      */
     public fun removeHost(host: HostView)
 
+    public fun setHostEmpty(hostView: HostView)
+
     /**
      * Select a host for the specified [iter].
      * We implicity assume that the task has been scheduled onto the host.

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/FilterScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/FilterScheduler.kt
@@ -98,10 +98,10 @@ public class FilterScheduler(
             }
         }
 
-        val availableHosts = usedHosts
+        val availableHosts = usedHosts.toMutableList()
         for (emptyHosts in emptyHostMap.values) {
             if (!emptyHosts.isEmpty()) {
-                usedHosts += emptyHosts.first()
+                availableHosts += emptyHosts.first()
             }
         }
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/FilterScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/FilterScheduler.kt
@@ -62,7 +62,7 @@ public class FilterScheduler(
         val hostType = hostView.host.getType()
 
         if (emptyHostMap.containsKey(hostType)) {
-            emptyHostMap[hostType]?.add(hostView);
+            emptyHostMap[hostType]?.add(hostView)
         } else {
             emptyHostMap[hostType] = mutableListOf(hostView)
         }
@@ -79,7 +79,7 @@ public class FilterScheduler(
 
         usedHosts.remove(hostView)
         if (emptyHostMap.containsKey(hostType)) {
-            emptyHostMap[hostType]?.add(hostView);
+            emptyHostMap[hostType]?.add(hostView)
         } else {
             emptyHostMap[hostType] = mutableListOf(hostView)
         }
@@ -101,7 +101,7 @@ public class FilterScheduler(
         val availableHosts = usedHosts
         for (emptyHosts in emptyHostMap.values) {
             if (!emptyHosts.isEmpty()) {
-                usedHosts += emptyHosts.first();
+                usedHosts += emptyHosts.first()
             }
         }
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/MemorizingScheduler.kt
@@ -73,6 +73,10 @@ public class MemorizingScheduler(
         numHosts--
     }
 
+    override fun setHostEmpty(hostView: HostView) {
+        // No-op
+    }
+
     override fun select(iter: MutableIterator<SchedulingRequest>): SchedulingResult {
         if (numHosts == 0) {
             return SchedulingResult(SchedulingResultType.FAILURE)

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/MemorizingTimeshift.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/MemorizingTimeshift.kt
@@ -88,6 +88,10 @@ public class MemorizingTimeshift(
         numHosts--
     }
 
+    override fun setHostEmpty(hostView: HostView) {
+        // No-op
+    }
+
     override fun select(iter: MutableIterator<SchedulingRequest>): SchedulingResult {
         if (numHosts == 0) {
             return SchedulingResult(SchedulingResultType.FAILURE)

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/TimeshiftScheduler.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/scheduler/timeshift/TimeshiftScheduler.kt
@@ -73,6 +73,10 @@ public class TimeshiftScheduler(
         hosts.remove(host)
     }
 
+    override fun setHostEmpty(hostView: HostView) {
+        // No-op
+    }
+
     override fun select(iter: MutableIterator<SchedulingRequest>): SchedulingResult {
         var result: SchedulingResult? = null
         for (req in iter) {

--- a/opendc-compute/opendc-compute-simulator/src/test/kotlin/org/opendc/compute/simulator/scheduler/FilterSchedulerTest.kt
+++ b/opendc-compute/opendc-compute-simulator/src/test/kotlin/org/opendc/compute/simulator/scheduler/FilterSchedulerTest.kt
@@ -97,9 +97,11 @@ internal class FilterSchedulerTest {
 
         val hostA = mockk<HostView>()
         every { hostA.host.getState() } returns HostState.DOWN
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -128,9 +130,11 @@ internal class FilterSchedulerTest {
 
         val hostA = mockk<HostView>()
         every { hostA.host.getState() } returns HostState.DOWN
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -142,7 +146,7 @@ internal class FilterSchedulerTest {
 
         // Make sure we get the first host both times
         assertAll(
-            { assertEquals(hostB, scheduler.select(mutableListOf(req).iterator()).host) },
+            { assertEquals(hostA, scheduler.select(mutableListOf(req).iterator()).host) },
             { assertEquals(hostA, scheduler.select(mutableListOf(req).iterator()).host) },
         )
     }
@@ -157,6 +161,7 @@ internal class FilterSchedulerTest {
 
         val host = mockk<HostView>()
         every { host.host.getState() } returns HostState.DOWN
+        every { host.host.getType() } returns "A"
 
         scheduler.addHost(host)
 
@@ -178,6 +183,7 @@ internal class FilterSchedulerTest {
 
         val host = mockk<HostView>()
         every { host.host.getState() } returns HostState.UP
+        every { host.host.getType() } returns "A"
 
         scheduler.addHost(host)
 
@@ -201,11 +207,13 @@ internal class FilterSchedulerTest {
         every { hostA.host.getState() } returns HostState.UP
         every { hostA.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostA.availableMemory } returns 512
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostB.availableMemory } returns 2048
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -230,6 +238,7 @@ internal class FilterSchedulerTest {
         every { host.host.getState() } returns HostState.UP
         every { host.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { host.availableMemory } returns 2048
+        every { host.host.getType() } returns "A"
 
         scheduler.addHost(host)
 
@@ -253,11 +262,13 @@ internal class FilterSchedulerTest {
         every { hostA.host.getState() } returns HostState.UP
         every { hostA.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostA.provisionedCpuCores } returns 3
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostB.provisionedCpuCores } returns 0
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -282,6 +293,7 @@ internal class FilterSchedulerTest {
         every { host.host.getState() } returns HostState.UP
         every { host.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { host.provisionedCpuCores } returns 0
+        every { host.host.getType() } returns "A"
 
         scheduler.addHost(host)
 
@@ -305,12 +317,14 @@ internal class FilterSchedulerTest {
         every { hostA.host.getState() } returns HostState.UP
         every { hostA.host.getModel() } returns HostModel(8 * 2600.0, 8, 2048)
         every { hostA.availableMemory } returns 512
+        every { hostA.host.getType() } returns "A"
         scheduler.addHost(hostA)
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 3200.0, 4, 2048)
         every { hostB.availableMemory } returns 512
+        every { hostB.host.getType() } returns "B"
         scheduler.addHost(hostB)
 
         val req = mockk<SchedulingRequest>()
@@ -334,11 +348,13 @@ internal class FilterSchedulerTest {
         every { hostA.host.getState() } returns HostState.UP
         every { hostA.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostA.instanceCount } returns 2
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostB.instanceCount } returns 0
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -372,12 +388,14 @@ internal class FilterSchedulerTest {
         every { hostA.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostA.host.getInstances() } returns emptySet()
         every { hostA.provisionedCpuCores } returns 3
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostB.host.getInstances() } returns setOf(reqA.task)
         every { hostB.provisionedCpuCores } returns 0
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -416,12 +434,14 @@ internal class FilterSchedulerTest {
         every { hostA.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostA.host.getInstances() } returns setOf(reqA.task)
         every { hostA.provisionedCpuCores } returns 3
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostB.host.getInstances() } returns emptySet()
         every { hostB.provisionedCpuCores } returns 0
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -459,6 +479,7 @@ internal class FilterSchedulerTest {
                 ),
             )
         every { hostA.provisionedGpuCores } returns 0
+        every { hostA.host.getType() } returns "A"
         scheduler.addHost(hostA)
 
         val hostB = mockk<HostView>()
@@ -474,6 +495,7 @@ internal class FilterSchedulerTest {
                 ),
             )
         every { hostB.provisionedGpuCores } returns 0
+        every { hostB.host.getType() } returns "B"
         scheduler.addHost(hostB)
 
         val req = mockk<SchedulingRequest>()
@@ -505,6 +527,7 @@ internal class FilterSchedulerTest {
                 ),
             )
         every { hostA.availableMemory } returns 512
+        every { hostA.host.getType() } returns "A"
         scheduler.addHost(hostA)
 
         val hostB = mockk<HostView>()
@@ -520,6 +543,7 @@ internal class FilterSchedulerTest {
                 ),
             )
         every { hostB.availableMemory } returns 512
+        every { hostB.host.getType() } returns "B"
         scheduler.addHost(hostB)
 
         val req = mockk<SchedulingRequest>()
@@ -543,11 +567,13 @@ internal class FilterSchedulerTest {
         every { hostA.host.getState() } returns HostState.UP
         every { hostA.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostA.availableMemory } returns 1024
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostB.availableMemory } returns 512
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -572,11 +598,13 @@ internal class FilterSchedulerTest {
         every { hostA.host.getState() } returns HostState.UP
         every { hostA.host.getModel() } returns HostModel(12 * 2600.0, 12, 2048)
         every { hostA.availableMemory } returns 1024
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostB.availableMemory } returns 512
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -601,11 +629,13 @@ internal class FilterSchedulerTest {
         every { hostA.host.getState() } returns HostState.UP
         every { hostA.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostA.provisionedCpuCores } returns 2
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostB.provisionedCpuCores } returns 0
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)
@@ -630,11 +660,13 @@ internal class FilterSchedulerTest {
         every { hostA.host.getState() } returns HostState.UP
         every { hostA.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostA.instanceCount } returns 2
+        every { hostA.host.getType() } returns "A"
 
         val hostB = mockk<HostView>()
         every { hostB.host.getState() } returns HostState.UP
         every { hostB.host.getModel() } returns HostModel(4 * 2600.0, 4, 2048)
         every { hostB.instanceCount } returns 0
+        every { hostB.host.getType() } returns "B"
 
         scheduler.addHost(hostA)
         scheduler.addHost(hostB)

--- a/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/TopologyFactories.kt
+++ b/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/TopologyFactories.kt
@@ -224,6 +224,7 @@ private fun HostJSONSpec.toHostSpec(clusterName: String): HostSpec {
     val hostSpec =
         HostSpec(
             createUniqueName(this.name, hostNames),
+            this.name,
             clusterName,
             machineModel,
             cpuPowerModel,

--- a/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/HostSpec.kt
+++ b/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/specs/HostSpec.kt
@@ -35,6 +35,7 @@ import org.opendc.simulator.engine.graph.distributionPolicies.FlowDistributorFac
  */
 public data class HostSpec(
     val name: String,
+    val type: String,
     val clusterName: String,
     val model: MachineModel,
     val cpuPowerModel: PowerModel,

--- a/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/OpenDCRunner.kt
+++ b/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/OpenDCRunner.kt
@@ -358,6 +358,7 @@ public class OpenDCRunner(
             val spec =
                 HostSpec(
                     "node-$clusterId-$position",
+                    "node-$clusterId",
                     clusterId,
                     MachineModel(processors, memoryUnits[0]),
                     cpuPowerModel,


### PR DESCRIPTION
## Summary

Updated the FilterScheduler to reduce redundant operations.

## Implementation Notes :hammer_and_pick:

The old implementation of FilterScheduler took all Hosts, filtered them, and sorted them. 
However, in most cases only a few different types of hosts are actually used by a data center. 
This means we can check only one of the hosts of each type instead of testing them all. 

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*