### PR TITLE
Converted maps in the FlowDistributor to Arrays for performance

### DIFF
--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/HostsProvisioningStep.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/provisioner/HostsProvisioningStep.kt
@@ -68,10 +68,11 @@ public class HostsProvisioningStep internal constructor(
             simPowerSources.add(simPowerSource)
             service.addPowerSource(simPowerSource)
 
-            val hostDistributor =
+            val powerDistributor =
                 FlowDistributorFactory.getFlowDistributor(
                     engine,
                     DistributionPolicy.MAX_MIN_FAIRNESS,
+                    cluster.hostSpecs.size,
                 )
 
             val carbonFragments = getCarbonFragments(cluster.powerSource.carbonTracePath)
@@ -90,6 +91,7 @@ public class HostsProvisioningStep internal constructor(
                     FlowDistributorFactory.getFlowDistributor(
                         engine,
                         DistributionPolicy.MAX_MIN_FAIRNESS,
+                        2,
                     )
                 FlowEdge(batteryDistributor, simPowerSource)
 
@@ -120,11 +122,11 @@ public class HostsProvisioningStep internal constructor(
 
                 carbonModel?.addReceiver(batteryPolicy)
 
-                FlowEdge(hostDistributor, batteryAggregator, ResourceType.POWER)
+                FlowEdge(powerDistributor, batteryAggregator, ResourceType.POWER)
 
                 service.addBattery(battery)
             } else {
-                FlowEdge(hostDistributor, simPowerSource, ResourceType.POWER)
+                FlowEdge(powerDistributor, simPowerSource, ResourceType.POWER)
             }
 
             // Create hosts, they are connected to the powerMux when SimMachine is created
@@ -141,7 +143,7 @@ public class HostsProvisioningStep internal constructor(
                         hostSpec.gpuPowerModel,
                         hostSpec.embodiedCarbon,
                         hostSpec.expectedLifetime,
-                        hostDistributor,
+                        powerDistributor,
                     )
 
                 require(simHosts.add(simHost)) { "Host with name ${hostSpec.name} already exists" }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
@@ -118,12 +118,6 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
             // instead iterate over the resources in the fragment as required resources not provided by the VM
             for (ResourceType resourceType : workload.getResourceTypes()) {
                 this.usedResourceTypes.add(resourceType);
-
-                //                this.resourcesSupplied.put(resourceType, 0.0);
-                //                this.newResourcesSupply.put(resourceType, 0.0);
-                //                this.resourcesDemand.put(resourceType, 0.0);
-                //                this.remainingWork.put(resourceType, 0.0);
-                //                this.workloadFinished.put(resourceType, false);
             }
         }
     }
@@ -146,11 +140,6 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
             if (supplier.getSupplierResourceType() != ResourceType.AUXILIARY) {
                 new FlowEdge(this, supplier);
                 this.usedResourceTypes.add(supplier.getSupplierResourceType());
-                //                this.resourcesSupplied.put(supplier.getSupplierResourceType(), 0.0);
-                //                this.newResourcesSupply.put(supplier.getSupplierResourceType(), 0.0);
-                //                this.resourcesDemand.put(supplier.getSupplierResourceType(), 0.0);
-                //                this.remainingWork.put(supplier.getSupplierResourceType(), 0.0);
-                //                this.workloadFinished.put(supplier.getSupplierResourceType(), false);
             }
         }
     }

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowDistributor.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowDistributor.java
@@ -73,25 +73,6 @@ public abstract class FlowDistributor extends FlowNode implements FlowSupplier, 
 
     protected double capacity; // What is the max capacity. Can probably be removed
 
-    //    protected final ArrayList<FlowEdge> consumerEdges = new ArrayList<>();
-    //    protected final ArrayList<Double> incomingDemands = new ArrayList<>(); // What is demanded by the consumers
-    //    protected final ArrayList<Double> outgoingSupplies = new ArrayList<>(); // What is supplied to the consumers
-    //
-    //    protected double totalIncomingDemand; // The total demand of all the consumers
-    //    protected HashMap<Integer, Double> currentIncomingSupplies = new HashMap<>(); // The current supply provided
-    // by the suppliers
-    //    protected Double totalIncomingSupply = 0.0; // The total supply provided by the suppliers
-    //
-    //    protected boolean outgoingDemandUpdateNeeded = false;
-    //    protected boolean outgoingSupplyUpdateNeeded = false;
-    //    protected Set<Integer> updatedDemands =
-    //            new HashSet<>(); // Array of consumers that updated their demand in this cycle
-    //
-    //    protected ResourceType supplierResourceType;
-    //    protected ResourceType consumerResourceType;
-    //
-    //    protected double capacity; // What is the max capacity. Can probably be removed
-
     public FlowDistributor(FlowEngine engine, int maxConsumers) {
         super(engine);
 
@@ -110,7 +91,6 @@ public abstract class FlowDistributor extends FlowNode implements FlowSupplier, 
 
         this.incomingDemands = new double[this.maxConsumers];
         this.outgoingSupplies = new double[this.maxConsumers];
-        //        this.updatedDemands = new boolean[this.maxConsumers];
     }
 
     public double getTotalIncomingDemand() {
@@ -189,7 +169,6 @@ public abstract class FlowDistributor extends FlowNode implements FlowSupplier, 
         }
 
         // Remove idx from consumers that updated their demands
-        //        this.updatedDemands[consumerIndex] = false;
         if (this.updatedDemands.contains(consumerIndex)) {
             this.updatedDemands.remove(Integer.valueOf(consumerIndex));
         }
@@ -211,8 +190,6 @@ public abstract class FlowDistributor extends FlowNode implements FlowSupplier, 
     public void removeSupplierEdge(FlowEdge supplierEdge) {
         // supplierIndex not always set, so we use 0 as default to avoid index out of bounds
         int idx = supplierEdge.getSupplierIndex() == -1 ? 0 : supplierEdge.getSupplierIndex();
-        // to keep index consistent, entries are neutralized instead of removed
-        //        this.supplierEdges.put(idx, null);
 
         this.supplierEdges.remove(idx);
         this.capacity -= supplierEdge.getCapacity();
@@ -220,7 +197,6 @@ public abstract class FlowDistributor extends FlowNode implements FlowSupplier, 
 
         if (this.supplierEdges.isEmpty()) {
             this.updatedDemands.clear();
-            //            Arrays.fill(this.updatedDemands, false);
         }
     }
 

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/EqualShareFlowDistributor.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/EqualShareFlowDistributor.java
@@ -36,8 +36,8 @@ import org.opendc.simulator.engine.graph.FlowDistributor;
  */
 public class EqualShareFlowDistributor extends FlowDistributor {
 
-    public EqualShareFlowDistributor(FlowEngine engine) {
-        super(engine);
+    public EqualShareFlowDistributor(FlowEngine engine, int maxConsumers) {
+        super(engine, maxConsumers);
     }
 
     /**
@@ -65,18 +65,19 @@ public class EqualShareFlowDistributor extends FlowDistributor {
      */
     @Override
     protected void updateOutgoingSupplies() {
-        double[] equalShare = distributeSupply(incomingDemands, outgoingSupplies, this.capacity);
+        double[] equalShare = distributeSupply(
+                incomingDemands, new ArrayList<>(this.currentIncomingSupplies.values()), this.capacity);
 
-        for (var consumerEdge : this.consumerEdges) {
-            this.pushOutgoingSupply(consumerEdge, equalShare[consumerEdge.getConsumerIndex()]);
+        for (int consumerIndex : this.usedConsumerIndices) {
+            this.pushOutgoingSupply(
+                    this.consumerEdges[consumerIndex], equalShare[consumerIndex], this.getConsumerResourceType());
         }
     }
 
     @Override
-    public double[] distributeSupply(ArrayList<Double> demands, ArrayList<Double> currentSupply, double totalSupply) {
-        int numConsumers = demands.size();
-        double[] allocation = new double[numConsumers];
-        double equalShare = totalSupply / numConsumers;
+    public double[] distributeSupply(double[] demands, ArrayList<Double> currentSupply, double totalSupply) {
+        double[] allocation = new double[this.numConsumers];
+        double equalShare = totalSupply / this.numConsumers;
 
         // Equal share regardless of individual demands
         Arrays.fill(allocation, equalShare);

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/FirstFitPolicyFlowDistributor.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/FirstFitPolicyFlowDistributor.java
@@ -25,7 +25,6 @@ package org.opendc.simulator.engine.graph.distributionPolicies;
 import java.util.ArrayList;
 import org.opendc.simulator.engine.engine.FlowEngine;
 import org.opendc.simulator.engine.graph.FlowDistributor;
-import org.opendc.simulator.engine.graph.FlowEdge;
 
 /**
  * A {@link FlowDistributor} that implements the First Fit policy for distributing flow.
@@ -37,8 +36,8 @@ import org.opendc.simulator.engine.graph.FlowEdge;
  */
 public class FirstFitPolicyFlowDistributor extends FlowDistributor {
 
-    public FirstFitPolicyFlowDistributor(FlowEngine engine) {
-        super(engine);
+    public FirstFitPolicyFlowDistributor(FlowEngine engine, int maxConsumers) {
+        super(engine, maxConsumers);
     }
 
     /**
@@ -90,8 +89,9 @@ public class FirstFitPolicyFlowDistributor extends FlowDistributor {
 
         double[] shares = distributeSupply(incomingDemands, currentPossibleSupplies, totalIncomingSupply);
 
-        for (FlowEdge consumerEdge : this.consumerEdges) {
-            this.pushOutgoingSupply(consumerEdge, shares[consumerEdge.getConsumerIndex()]);
+        for (int consumerIndex : this.usedConsumerIndices) {
+            this.pushOutgoingSupply(
+                    this.consumerEdges[consumerIndex], shares[consumerIndex], this.getConsumerResourceType());
         }
     }
 
@@ -108,8 +108,8 @@ public class FirstFitPolicyFlowDistributor extends FlowDistributor {
      * @see #updateOutgoingSupplies()
      */
     @Override
-    public double[] distributeSupply(ArrayList<Double> demands, ArrayList<Double> currentSupply, double totalSupply) {
-        int numConsumers = demands.size();
+    public double[] distributeSupply(double[] demands, ArrayList<Double> currentSupply, double totalSupply) {
+        int numConsumers = demands.length;
         double[] allocation = new double[numConsumers];
 
         // Create a copy of current supply to track remaining capacity as we allocate
@@ -117,7 +117,7 @@ public class FirstFitPolicyFlowDistributor extends FlowDistributor {
 
         // For each demand, try to satisfy it using suppliers in order
         for (int i = 0; i < numConsumers; i++) {
-            double remainingDemand = demands.get(i);
+            double remainingDemand = demands[i];
             double totalAllocated = 0.0;
 
             if (remainingDemand > 0) {

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/FlowDistributorFactory.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/FlowDistributorFactory.java
@@ -56,22 +56,23 @@ public class FlowDistributorFactory {
         }
     }
 
-    public static FlowDistributor getFlowDistributor(FlowEngine flowEngine, DistributionPolicy distributionPolicyType) {
+    public static FlowDistributor getFlowDistributor(
+            FlowEngine flowEngine, DistributionPolicy distributionPolicyType, int maxConsumers) {
 
         return switch (distributionPolicyType) {
             case BEST_EFFORT -> new BestEffortFlowDistributor(
-                    flowEngine, distributionPolicyType.getProperty("updateIntervalLength", Long.class));
-            case EQUAL_SHARE -> new EqualShareFlowDistributor(flowEngine);
-            case FIRST_FIT -> new FirstFitPolicyFlowDistributor(flowEngine);
+                    flowEngine, distributionPolicyType.getProperty("updateIntervalLength", Long.class), maxConsumers);
+            case EQUAL_SHARE -> new EqualShareFlowDistributor(flowEngine, maxConsumers);
+            case FIRST_FIT -> new FirstFitPolicyFlowDistributor(flowEngine, maxConsumers);
             case FIXED_SHARE -> {
                 if (!distributionPolicyType.getPropertyNames().contains("shareRatio")) {
                     throw new IllegalArgumentException(
                             "FixedShare distribution policy requires a 'shareRatio' property to be set.");
                 }
                 yield new FixedShareFlowDistributor(
-                        flowEngine, distributionPolicyType.getProperty("shareRatio", Double.class));
+                        flowEngine, distributionPolicyType.getProperty("shareRatio", Double.class), maxConsumers);
             }
-            default -> new MaxMinFairnessFlowDistributor(flowEngine);
+            default -> new MaxMinFairnessFlowDistributor(flowEngine, maxConsumers);
         };
     }
 }


### PR DESCRIPTION
## Summary

Turned all maps used by the FlowDistributor for consumers into arrays. 
The FlowDistributor is used a lot, and the constant hashing was costing a significant amount of computations. 
Jumping into an array is much cheaper. 

## Implementation Notes :hammer_and_pick:

Every FlowDistributor 

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

FlowDistributors now require a maxConsumer parameter.

*Simply specify none (N/A) if not applicable.*