### PR TITLE
Removed a bug in MaxMinFlowDistributor.

### DIFF
--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/VirtualMachine.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/VirtualMachine.java
@@ -61,14 +61,6 @@ public final class VirtualMachine extends SimWorkload implements FlowSupplier {
     private final PerformanceCounters[] resourcePerformanceCounters =
             new PerformanceCounters[ResourceType.values().length];
 
-    //    private final Hashtable<ResourceType, Double> resourceDemands = new Hashtable<>();
-    //    private final Hashtable<ResourceType, Double> resourceSupplies = new Hashtable<>();
-    //    private final Hashtable<ResourceType, Double> resourceCapacities = new Hashtable<>();
-    //    private final Hashtable<ResourceType, Double> resourceTimeScalingFactor = new Hashtable<>(); // formerly known
-    // as d
-    //    private final Hashtable<ResourceType, FlowEdge> distributorEdges = new Hashtable<>();
-    //    private final Hashtable<ResourceType, PerformanceCounters> resourcePerformanceCounters = new Hashtable<>();
-
     private final long checkpointInterval;
     private final long checkpointDuration;
     private final double checkpointIntervalScaling;
@@ -326,7 +318,6 @@ public final class VirtualMachine extends SimWorkload implements FlowSupplier {
      */
     @Override
     public void pushOutgoingDemand(FlowEdge supplierEdge, double newDemand) {
-        // FIXME: Needs to be assigned to specific resource if multiple exist -> add resource Id as parameter
         this.pushOutgoingDemand(supplierEdge, newDemand, supplierEdge.getSupplierResourceType());
     }
 
@@ -338,7 +329,6 @@ public final class VirtualMachine extends SimWorkload implements FlowSupplier {
      */
     @Override
     public void pushOutgoingDemand(FlowEdge supplierEdge, double newDemand, ResourceType resourceType) {
-        // FIXME: Needs to be assigned to specific resource if multiple exist -> add resource Id as parameter
         this.resourceDemands[resourceType.ordinal()] = newDemand;
         this.distributorEdges[resourceType.ordinal()].pushDemand(newDemand, false, resourceType);
     }

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowSupplier.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowSupplier.java
@@ -35,7 +35,8 @@ public interface FlowSupplier {
     default void handleIncomingDemand(
             FlowEdge consumerEdge, double newDemand, ResourceType resourceType, int consumerCount) {
         handleIncomingDemand(consumerEdge, newDemand);
-    };
+    }
+    ;
 
     void pushOutgoingSupply(FlowEdge consumerEdge, double newSupply);
 

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowSupplier.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/FlowSupplier.java
@@ -35,8 +35,7 @@ public interface FlowSupplier {
     default void handleIncomingDemand(
             FlowEdge consumerEdge, double newDemand, ResourceType resourceType, int consumerCount) {
         handleIncomingDemand(consumerEdge, newDemand);
-    }
-    ;
+    };
 
     void pushOutgoingSupply(FlowEdge consumerEdge, double newSupply);
 

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/MaxMinFairnessFlowDistributor.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/MaxMinFairnessFlowDistributor.java
@@ -56,8 +56,6 @@ public class MaxMinFairnessFlowDistributor extends FlowDistributor {
         }
 
         this.outgoingDemandUpdateNeeded = false;
-
-//        this.invalidate();
     }
 
     // TODO: This should probably be moved to the distribution strategy

--- a/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/MaxMinFairnessFlowDistributor.java
+++ b/opendc-simulator/opendc-simulator-flow/src/main/java/org/opendc/simulator/engine/graph/distributionPolicies/MaxMinFairnessFlowDistributor.java
@@ -43,13 +43,21 @@ public class MaxMinFairnessFlowDistributor extends FlowDistributor {
     }
 
     protected void updateOutgoingDemand() {
+        if (this.totalIncomingDemand == this.previousTotalDemand) {
+            this.outgoingDemandUpdateNeeded = false;
+            this.updateOutgoingSupplies();
+            return;
+        }
+
+        this.previousTotalDemand = this.totalIncomingDemand;
+
         for (FlowEdge supplierEdge : this.supplierEdges.values()) {
             this.pushOutgoingDemand(supplierEdge, this.totalIncomingDemand / this.supplierEdges.size());
         }
 
         this.outgoingDemandUpdateNeeded = false;
 
-        this.invalidate();
+//        this.invalidate();
     }
 
     // TODO: This should probably be moved to the distribution strategy


### PR DESCRIPTION
## Summary

Updated the FlowDistributor to prevent invalidation immediately after sending a new demand. 
The previous version of the MaxMinFlowDistributor directly invalidated the distributor after updating the outgoing demand. 
This would cause the demand to exceed the supply, resulting in the distributor being overloaded. 

Calculating the distribution when a distributor is overloaded is costly. 
This update resolves the issue by removing the invalidate() method.