### PR TITLE
Dockerize M3SA experiment module

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,20 @@
 **/node_modules
 
 **/Dockerfile
+docker-compose*.yml
+
+# Python caches
+**/__pycache__/
+**/venv/
+**/*.pyc
+
+# OS files
+.DS_Store
+
+# Large data (mounted at runtime, not baked into the image)
+data/outputs/
+data/raw_traces/
+output/
+
+# Site docs
+site/

--- a/docker-compose.m3sa.yml
+++ b/docker-compose.m3sa.yml
@@ -1,0 +1,17 @@
+services:
+  m3sa:
+    build:
+      context: .
+      dockerfile: opendc-experiments/opendc-experiments-m3sa/Dockerfile
+    image: opendc-m3sa:latest
+    volumes:
+      # Mount data directory (topologies, workload traces, scenarios)
+      - ./data:/opt/opendc/data
+      # Mount output directory for results
+      - ./output:/opt/opendc/output
+    # Override command with your experiment + M3SA config
+    # Example:
+    #   docker compose -f docker-compose.m3sa.yml run m3sa \
+    #     --experiment-path data/scenario.json \
+    #     --m3sa-setup-path data/m3sa_setup.json
+    command: ["--experiment-path", "data/scenario.json"]

--- a/opendc-experiments/opendc-experiments-m3sa/Dockerfile
+++ b/opendc-experiments/opendc-experiments-m3sa/Dockerfile
@@ -1,0 +1,50 @@
+FROM eclipse-temurin:21-jdk-jammy AS build
+
+# Install Python 3 + pip for the M3SA analysis
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip python3-venv && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy Gradle wrapper first (for caching)
+COPY gradlew /app/
+COPY gradle /app/gradle
+WORKDIR /app
+RUN ./gradlew --version
+
+# Copy the full project and build
+COPY ./ /app/
+RUN ./gradlew --no-daemon :opendc-experiments:opendc-experiments-m3sa:installDist
+
+# Install Python dependencies
+RUN pip3 install --no-cache-dir -r \
+    opendc-experiments/opendc-experiments-m3sa/src/main/python/requirements.txt
+
+# ---- Runtime stage ----
+FROM eclipse-temurin:21-jre-jammy
+
+# Install Python 3 runtime
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy Python packages from the build stage
+COPY --from=build /usr/lib/python3 /usr/lib/python3
+COPY --from=build /usr/local/lib/python3.10 /usr/local/lib/python3.10
+
+# Copy M3SA JVM distribution
+COPY --from=build /app/opendc-experiments/opendc-experiments-m3sa/build/install/opendc-experiments-m3sa \
+    /opt/opendc-m3sa
+
+# Copy Python source code
+COPY --from=build /app/opendc-experiments/opendc-experiments-m3sa/src/main/python \
+    /opt/opendc-m3sa/python
+
+WORKDIR /opt/opendc
+
+# Default entrypoint runs the M3SA CLI
+ENTRYPOINT ["/opt/opendc-m3sa/bin/opendc-experiments-m3sa"]
+
+LABEL org.opencontainers.image.title="OpenDC M3SA Runner"
+LABEL org.opencontainers.image.description="Multi-Meta-Model Simulation Analysis for OpenDC"
+LABEL org.opencontainers.image.source="https://github.com/atlarge-research/opendc"
+LABEL org.opencontainers.image.vendor="AtLarge Research"

--- a/opendc-experiments/opendc-experiments-m3sa/README.md
+++ b/opendc-experiments/opendc-experiments-m3sa/README.md
@@ -1,0 +1,70 @@
+# M3SA — Multi-Meta-Model Simulation Analysis
+
+M3SA runs OpenDC simulations and then performs Python-based analysis on the results.
+
+## Quick Start with Docker
+
+### Prerequisites
+- Docker Desktop installed and **running**
+
+### Build
+From the **repository root**:
+```bash
+docker build -t opendc-m3sa -f opendc-experiments/opendc-experiments-m3sa/Dockerfile .
+```
+
+### Run
+```bash
+# Simulation only (no M3SA analysis)
+docker run --rm \
+  -v $(pwd)/data:/opt/opendc/data \
+  -v $(pwd)/output:/opt/opendc/output \
+  opendc-m3sa \
+  --experiment-path data/scenario.json
+
+# Simulation + M3SA analysis
+docker run --rm \
+  -v $(pwd)/data:/opt/opendc/data \
+  -v $(pwd)/output:/opt/opendc/output \
+  opendc-m3sa \
+  --experiment-path data/scenario.json \
+  --m3sa-setup-path data/m3sa_setup.json
+```
+
+### Using Docker Compose
+```bash
+docker compose -f docker-compose.m3sa.yml up --build
+```
+
+## Running Without Docker
+
+### Prerequisites
+- JDK 21
+- Python 3.10+ with `pip`
+
+### Setup Python dependencies
+```bash
+cd opendc-experiments/opendc-experiments-m3sa/src/main/python
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Run via Gradle
+```bash
+./gradlew :opendc-experiments:opendc-experiments-m3sa:run \
+  --args="--experiment-path data/scenario.json"
+```
+
+## M3SA Setup File
+
+The M3SA setup JSON configures the analysis. See `src/test/resources/m3saSetups/` for examples.
+
+Key fields:
+| Field | Description |
+|---|---|
+| `metric` | Parquet column to analyze (e.g. `power_draw`, `energy_usage`) |
+| `window_size` | Aggregation window size |
+| `plot_type` | `time_series`, `cumulative`, or `cumulative_time_series` |
+| `metamodel` | `true` to compute a meta-model across scenarios |
+| `meta_function` | `mean` or `median` |

--- a/opendc-experiments/opendc-experiments-m3sa/build.gradle.kts
+++ b/opendc-experiments/opendc-experiments-m3sa/build.gradle.kts
@@ -28,7 +28,12 @@ plugins {
     `testing-conventions`
     `jacoco-conventions`
     distribution
+    application
     kotlin("plugin.serialization") version "1.9.22"
+}
+
+application {
+    mainClass.set("org.opendc.experiments.m3sa.runner.M3SACli")
 }
 
 dependencies {

--- a/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
+++ b/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
@@ -61,15 +61,57 @@ public fun m3saAnalyze(
             "-o",
             outputFolderPath,
         )
+            .directory(Paths.get(m3saExecPath).toAbsolutePath().normalize().toFile())
             .redirectErrorStream(true)
             .start()
 
     val exitCode = process.waitFor()
     val output = process.inputStream.bufferedReader().readText()
+    
     if (exitCode == 0) {
         println("[M3SA says] Success:\n$output")
+        return
+    } 
+
+    if (output.contains("ModuleNotFoundError") || output.contains("No such file or directory")) {
+        println("[M3SA] Local Python dependencies missing. Falling back to Docker (opendc-m3sa)...")
+        runViaDocker(outputFolderPath, m3saSetupPath)
     } else {
         println("[M3SA says] Exit code $exitCode; Output:\n$output")
         throw RuntimeException("M3SA analysis failed with exit code $exitCode")
+    }
+}
+
+private fun runViaDocker(outputFolderPath: String, m3saSetupPath: String) {
+    // We mount the absolute paths to the Docker container
+    val absOutput = Paths.get(outputFolderPath).toAbsolutePath().normalize().toString()
+    val absSetup = Paths.get(m3saSetupPath).toAbsolutePath().normalize().toString()
+    val dockerOutput = "/opt/opendc/output"
+    val dockerSetup = "/opt/opendc/setup.json"
+
+    val process = ProcessBuilder(
+        "docker", "run", "--rm",
+        "--entrypoint", "python3",
+        // Mount output directory where M3SA writes its plots
+        "-v", "$absOutput:$dockerOutput",
+        // Mount the setup file directly
+        "-v", "$absSetup:$dockerSetup",
+        "opendc-m3sa",
+        "/opt/opendc-m3sa/python/main.py",
+        dockerSetup,
+        "$dockerOutput/raw-output",
+        "-o", dockerOutput
+    )
+        .redirectErrorStream(true)
+        .start()
+
+    val exitCode = process.waitFor()
+    val output = process.inputStream.bufferedReader().readText()
+
+    if (exitCode == 0) {
+        println("[M3SA Docker] Success:\n$output")
+    } else {
+        println("[M3SA Docker] Exit code $exitCode; Output:\n$output")
+        throw RuntimeException("M3SA analysis via Docker failed with exit code $exitCode. Have you built the opendc-m3sa image?")
     }
 }

--- a/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
+++ b/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
@@ -67,11 +67,11 @@ public fun m3saAnalyze(
 
     val exitCode = process.waitFor()
     val output = process.inputStream.bufferedReader().readText()
-    
+
     if (exitCode == 0) {
         println("[M3SA says] Success:\n$output")
         return
-    } 
+    }
 
     if (output.contains("ModuleNotFoundError") || output.contains("No such file or directory")) {
         println("[M3SA] Local Python dependencies missing. Falling back to Docker (opendc-m3sa)...")
@@ -82,28 +82,32 @@ public fun m3saAnalyze(
     }
 }
 
-private fun runViaDocker(outputFolderPath: String, m3saSetupPath: String) {
+private fun runViaDocker(
+    outputFolderPath: String,
+    m3saSetupPath: String,
+) {
     // We mount the absolute paths to the Docker container
     val absOutput = Paths.get(outputFolderPath).toAbsolutePath().normalize().toString()
     val absSetup = Paths.get(m3saSetupPath).toAbsolutePath().normalize().toString()
     val dockerOutput = "/opt/opendc/output"
     val dockerSetup = "/opt/opendc/setup.json"
 
-    val process = ProcessBuilder(
-        "docker", "run", "--rm",
-        "--entrypoint", "python3",
-        // Mount output directory where M3SA writes its plots
-        "-v", "$absOutput:$dockerOutput",
-        // Mount the setup file directly
-        "-v", "$absSetup:$dockerSetup",
-        "opendc-m3sa",
-        "/opt/opendc-m3sa/python/main.py",
-        dockerSetup,
-        "$dockerOutput/raw-output",
-        "-o", dockerOutput
-    )
-        .redirectErrorStream(true)
-        .start()
+    val process =
+        ProcessBuilder(
+            "docker", "run", "--rm",
+            "--entrypoint", "python3",
+            // Mount output directory where M3SA writes its plots
+            "-v", "$absOutput:$dockerOutput",
+            // Mount the setup file directly
+            "-v", "$absSetup:$dockerSetup",
+            "opendc-m3sa",
+            "/opt/opendc-m3sa/python/main.py",
+            dockerSetup,
+            "$dockerOutput/raw-output",
+            "-o", dockerOutput,
+        )
+            .redirectErrorStream(true)
+            .start()
 
     val exitCode = process.waitFor()
     val output = process.inputStream.bufferedReader().readText()

--- a/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/scenario/M3SAFactories.kt
+++ b/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/scenario/M3SAFactories.kt
@@ -34,5 +34,11 @@ private val experimentReader = ExperimentReader()
  * @return A list of Scenarios.
  */
 public fun getOutputFolder(file: File): String {
-    return experimentReader.read(file).outputFolder + "/outputs"
+    val experiment = experimentReader.read(file)
+    val name = experiment.name
+    return if (name.isNotEmpty() && !name.startsWith("/")) {
+        "${experiment.outputFolder}/$name"
+    } else {
+        "${experiment.outputFolder}$name"
+    }
 }


### PR DESCRIPTION
## Summary

Dockerized M3SA experiment module. Removes issues with paths, configurations, etc.


## Implementation Notes :hammer_and_pick:

1. Docker config
2. M3SA Kotlin analyzer for automatic, if Docker container, if the system missed the required python libs
3. Fixed a bug in the output folder generation logic


## External Dependencies :four_leaf_clover:

* Docker

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*