### PR TITLE
Added workflow_dispatch to all github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ master ]
   merge_group:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy app.opendc.org
 on:
   push:
     branches: ["prod"]
+  workflow_dispatch:
 
 jobs:
   deploy-app:

--- a/.github/workflows/test-gradle-rc.yml
+++ b/.github/workflows/test-gradle-rc.yml
@@ -2,6 +2,7 @@ name: Test latest Gradle RC
 on:
   schedule:
     - cron: 0 0 * * 0 # weekly
+  workflow_dispatch:
 
 jobs:
   gradle-rc:

--- a/.github/workflows/test-java-ea.yml
+++ b/.github/workflows/test-java-ea.yml
@@ -2,6 +2,7 @@ name: Test Java EA release
 on:
   schedule:
     - cron: 0 0 * * 0 # weekly
+  workflow_dispatch:
 
 jobs:
   java-ea:


### PR DESCRIPTION
Added workflow_dispatch to all github Actions so they can be triggered from Github.com directly

## Summary

worklflow_dispatch enables users to trigger github actions from the website directly. This can be helpfull in the future.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*