### PR TITLE
Added automatic website deployment when pushing to gh-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches: ["prod"]
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Publish website docker image"]
+    types: [completed]
 
 jobs:
   deploy-app:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Create SSH key

--- a/README.md
+++ b/README.md
@@ -22,17 +22,18 @@ The latest release will be marked _latest_.
 
 ## Documentation
 
-You can find the OpenDC documentation [on the website](https://opendc.org/opendc/).
+You can find the OpenDC documentation [on the website](https://opendc.org).
 The documentation is divided into several sections:
 
-* [Getting Started](https://opendc.org/opendc/docs/category/getting-started/)
-* [Tutorials](https://opendc.org/opendc/docs/category/tutorials/)
-* [Advanced Guides](https://opendc.org/opendc/docs/category/advanced-guides/)
-* [Where to Get Support](https://opendc.org/opendc/community/support/)
-* [Contributing Guide](https://opendc.org/opendc/community/contributing/)
+* [Getting Started](https://opendc.org/learn/category/getting-started)
+* [Tutorials](https://opendc.org/learn/category/tutorials)
+* [Where to Get Support](https://opendc.org/community/support)
+* [Contributing Guide](https://opendc.org/community/contributing)
 
-The source code for the documentation is located in the [gh-pages branch](https://github.com/atlarge-research/opendc/tree/gh-pages).
-Push to that branch to update the documentation.
+You find information about the research projects and publications related to OpenDC in the [research section](https://opendc.org/research/publications).
+
+The source code for the website is located in the [gh-pages branch](https://github.com/atlarge-research/opendc/tree/gh-pages).
+Push to that branch to update the website.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

When a new version of the static website is created by the gh-pages created, the website automatically gets deployed. 

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A 

*Simply specify none (N/A) if not applicable.*