### PR TITLE
Updated deploy.yml to trigger on website publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,13 +4,12 @@ on:
   push:
     branches: ["prod"]
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Publish website docker image"]
-    types: [completed]
+  repository_dispatch:
+    types: [publish-website-completed]
 
 jobs:
   deploy-app:
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name != 'workflow_run' }}
+    if: ${{ github.event_name != 'repository_dispatch' || github.event.action == 'publish-completed' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Create SSH key


### PR DESCRIPTION
## Summary

Added an extra trigger to the deploy.yml to trigger when opendc-website is published. 
This should automate the pushing and deploying of the website when changes are made to at opendc-website.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*