### PR TITLE
Updated the benchmark submit to push to a release file

### DIFF
--- a/.github/scripts/update_history.py
+++ b/.github/scripts/update_history.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
 """
-Append the current JMH results to benchmark-history.json and overwrite
-benchmark-latest.json on the benchmark-data branch working directory.
+Append the current JMH results to the benchmark history and write the updated
+history to a new file.
 
 Usage:
-    python update_history.py <results.json> <output_dir> <commit_sha> [<pr_number>]
-
-<output_dir> is the directory where benchmark-history.json and
-benchmark-latest.json will be written (the benchmark-data checkout root).
+    python update_history.py <results.json> <existing-history.json> <output.json> <commit_sha>
 """
 
 import json
@@ -17,35 +14,34 @@ from pathlib import Path
 
 
 def main() -> None:
-    if len(sys.argv) < 4:
-        print("Usage: update_history.py <results.json> <output_dir> <commit_sha> [<pr_number>]", file=sys.stderr)
+    if len(sys.argv) < 5:
+        print(
+            "Usage: update_history.py <results.json> <existing-history.json> <output.json> <commit_sha>",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     results_path = Path(sys.argv[1])
-    output_dir = Path(sys.argv[2])
-    commit_sha = sys.argv[3]
-    pr_number = int(sys.argv[4]) if len(sys.argv) > 4 else None
+    existing_path = Path(sys.argv[2])
+    output_path = Path(sys.argv[3])
+    commit_sha = sys.argv[4]
 
     results = json.loads(results_path.read_text())
 
-    # Tag each result entry with the commit so compare_benchmarks.py can display it
     for entry in results:
         entry["_meta_commit"] = commit_sha
 
-    history_path = output_dir / "benchmark-history.json"
-    history = json.loads(history_path.read_text()) if history_path.exists() else []
+    history = json.loads(existing_path.read_text()) if existing_path.exists() else []
 
     history.append(
         {
             "commit": commit_sha,
-            "pr": pr_number,
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "results": results,
         }
     )
 
-    history_path.write_text(json.dumps(history, indent=2))
-
+    output_path.write_text(json.dumps(history, indent=2))
     print(f"Stored results for commit {commit_sha[:7]} ({len(results)} benchmark(s)).")
 
 

--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -43,11 +43,13 @@ jobs:
         id: pr
         run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
 
-      - name: Fetch baseline from benchmark-data branch
+      - name: Fetch baseline from benchmark-data release
         run: |
-          git fetch origin benchmark-data 2>/dev/null || true
-          git show origin/benchmark-data:benchmark-history.json > baseline.json 2>/dev/null \
+          gh release download benchmark-data --asset benchmark-history.json \
+            --output baseline.json 2>/dev/null \
             || echo "[]" > baseline.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate comparison comment
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ jobs:
           path: pr-number.txt
           retention-days: 1
 
-  # ── Master push: store results on the benchmark-data branch ──────────────────
+  # ── Master push: store results in the benchmark-data GitHub Release ───────────
   store-results:
     name: Store benchmark results
     if: github.event_name == 'push'
@@ -77,27 +77,29 @@ jobs:
           name: benchmark-results
           path: current-results
 
-      - name: Check out or create benchmark-data branch
+      - name: Download existing benchmark history
         run: |
-          git fetch origin benchmark-data 2>/dev/null || true
-          if git rev-parse --verify origin/benchmark-data 2>/dev/null; then
-            git worktree add benchmark-data-dir origin/benchmark-data
-          else
-            git worktree add --orphan -b benchmark-data benchmark-data-dir
-          fi
+          gh release download benchmark-data --asset benchmark-history.json \
+            --output existing-history.json 2>/dev/null \
+            || echo "[]" > existing-history.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update history
         run: |
           python .github/scripts/update_history.py \
             current-results/results.json \
-            benchmark-data-dir \
+            existing-history.json \
+            updated-history.json \
             "${{ github.sha }}"
 
-      - name: Commit and push
+      - name: Upload to release
         run: |
-          git -C benchmark-data-dir config user.name  "github-actions[bot]"
-          git -C benchmark-data-dir config user.email "github-actions[bot]@users.noreply.github.com"
-          git -C benchmark-data-dir add benchmark-history.json
-          git -C benchmark-data-dir commit \
-            -m "chore: benchmark results for ${{ github.sha }}"
-          git -C benchmark-data-dir push origin HEAD:benchmark-data
+          gh release upload benchmark-data updated-history.json \
+            --name benchmark-history.json --clobber 2>/dev/null \
+            || gh release create benchmark-data \
+              --title "Benchmark Data" \
+              --notes "Permanent storage for benchmark history. Managed automatically by CI." \
+              updated-history.json#benchmark-history.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Currently, the benchmark results are pushed to a branch. 
However, this is not intuitive. Instead, we are now pushing to a Github Release file. 

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*