### PR TITLE
Updated build and benchmark to only run on atlarge-research/opendc repo

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -48,8 +48,8 @@ jobs:
           gh release download benchmark-data \
             --repo atlarge-research/opendc \
             -A benchmark-history.json \
-            -O baseline.json 2>/dev/null \
-            || echo "[]" > baseline.json
+            -O baseline.json \
+            || { echo "Warning: Could not fetch baseline, using empty baseline"; echo "[]" > baseline.json; }
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   benchmark:
     name: Run CIBenchmark
+    if: github.repository == 'atlarge-research/opendc'
     runs-on: ubuntu-latest
 
     permissions:
@@ -61,7 +62,7 @@ jobs:
   # ── Master push: store results in the benchmark-data GitHub Release ───────────
   store-results:
     name: Store benchmark results
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'atlarge-research/opendc'
     needs: benchmark
     runs-on: ubuntu-latest
 
@@ -81,8 +82,8 @@ jobs:
         run: |
           gh release download benchmark-data \
             --repo atlarge-research/opendc \
-            --pattern benchmark-history.json \
-            --output existing-history.json 2>/dev/null \
+            -A benchmark-history.json \
+            -O existing-history.json 2>/dev/null \
             || echo "[]" > existing-history.json
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     name: Build (Java ${{ matrix.java }} - ${{ matrix.os }})
+    if: github.repository == 'atlarge-research/opendc'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -75,6 +76,7 @@ jobs:
           files: ./build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
   build-docker:
     name: Build Docker Images
+    if: github.repository == 'atlarge-research/opendc'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Updated build and benchmark to only run on atlarge-research/opendc repo. 

This is done so it won't run the full CI when someone updates their fork / branch.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*