### PR TITLE
Chore/update Kotlin 2.3.20  & Quarkus 3.33.1

### DIFF
--- a/buildSrc/src/main/kotlin/jacoco-aggregation.gradle.kts
+++ b/buildSrc/src/main/kotlin/jacoco-aggregation.gradle.kts
@@ -45,9 +45,8 @@ dependencies {
     }
 }
 
-@Suppress("UnstableApiUsage")
 val codeCoverageReport by reporting.reports.creating(JacocoCoverageReport::class) {
-    testType.set(TestSuiteType.UNIT_TEST)
+    testSuiteName.set("test")
 }
 
 tasks.check {

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -20,8 +20,6 @@
  * SOFTWARE.
  */
 
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     id("java-conventions")
     kotlin("jvm")
@@ -35,9 +33,4 @@ kotlin {
         val javaVersion = project.defaultVersionCatalog.getVersion("java")
         languageVersion.set(JavaLanguageVersion.of(javaVersion))
     }
-}
-
-tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
-    kotlinOptions.freeCompilerArgs += "-Xjvm-default=all"
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ clikt = "4.2.1"
 commons-math3 = "3.6.1"
 dokka = "1.9.10"
 hadoop = "3.3.6"
-hypersistence-utils = "3.7.3"
+hypersistence-utils = "3.15.2"
 jackson = "2.16.1"
 jandex-gradle = "1.1.0"
 java = "21"
@@ -13,10 +13,10 @@ jmh-gradle = "0.7.1"
 jakarta = "3.0.2"
 jakarta-ws-rs = "3.1.0"
 junit-jupiter = "5.10.2"
-kotlin = "1.9.22"
+kotlin = "2.3.20"
 kotlin-logging = "3.0.5"
 kotlinx-coroutines = "1.8.0"
-log4j = "2.23.0"
+log4j = "2.25.3"
 microprofile-rest-client = "3.0.1"
 microprofile-openapi = "3.1.1"
 microprofile-config = "3.1"
@@ -24,8 +24,8 @@ mockk = "1.13.9"
 node = "18.15.0"
 parquet = "1.13.1"
 progressbar = "0.10.0"
-quarkus = "3.8.0"
-quarkus-quinoa = "2.3.4"
+quarkus = "3.33.1"
+quarkus-quinoa = "2.8.1"
 sentry = "7.4.0"
 slf4j = "2.0.9"
 spotless = "6.25.0"
@@ -86,12 +86,12 @@ quarkus-hibernate-validator = { module = "io.quarkus:quarkus-hibernate-validator
 quarkus-jdbc-h2 = { module = "io.quarkus:quarkus-jdbc-h2" }
 quarkus-jdbc-postgresql = { module = "io.quarkus:quarkus-jdbc-postgresql" }
 quarkus-flyway = { module = "io.quarkus:quarkus-flyway" }
-hypersistence-utils-hibernate = { module = "io.hypersistence:hypersistence-utils-hibernate-63", version.ref = "hypersistence-utils" }
+hypersistence-utils-hibernate = { module = "io.hypersistence:hypersistence-utils-hibernate-71", version.ref = "hypersistence-utils" }
 quarkus-quinoa-runtime = { module = "io.quarkiverse.quinoa:quarkus-quinoa", version.ref = "quarkus-quinoa" }
 quarkus-quinoa-deployment = { module = "io.quarkiverse.quinoa:quarkus-quinoa-deployment", version.ref = "quarkus-quinoa" }
 
 # Quarkus (Testing)
-quarkus-junit5-core = { module = "io.quarkus:quarkus-junit5" }
+quarkus-junit5-core = { module = "io.quarkus:quarkus-junit" }
 quarkus-jacoco = { module = "io.quarkus:quarkus-jacoco" }
 quarkus-panache-mock = { module = "io.quarkus:quarkus-panache-mock" }
 quarkus-test-security = { module = "io.quarkus:quarkus-test-security" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/opendc-common/build.gradle.kts
+++ b/opendc-common/build.gradle.kts
@@ -26,7 +26,7 @@ description = "Common functionality used across OpenDC modules"
 // Build configuration
 plugins {
     `kotlin-library-conventions`
-    kotlin("plugin.serialization") version "1.9.22"
+    kotlin("plugin.serialization") version "2.3.20"
 }
 
 val serializationVersion = "1.6.0"

--- a/opendc-compute/opendc-compute-simulator/build.gradle.kts
+++ b/opendc-compute/opendc-compute-simulator/build.gradle.kts
@@ -25,7 +25,7 @@ description = "Simulator for OpenDC Compute"
 // Build configuration
 plugins {
     `kotlin-library-conventions`
-    kotlin("plugin.serialization") version "1.9.22"
+    kotlin("plugin.serialization") version "2.3.20"
 }
 
 dependencies {

--- a/opendc-compute/opendc-compute-topology/build.gradle.kts
+++ b/opendc-compute/opendc-compute-topology/build.gradle.kts
@@ -25,7 +25,7 @@ description = "OpenDC Compute Topology implementation"
 // Build configuration
 plugins {
     `kotlin-library-conventions`
-    kotlin("plugin.serialization") version "1.9.22"
+    kotlin("plugin.serialization") version "2.3.20"
 }
 
 dependencies {

--- a/opendc-experiments/opendc-experiments-base/build.gradle.kts
+++ b/opendc-experiments/opendc-experiments-base/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
     `testing-conventions`
     `jacoco-conventions`
     distribution
-    kotlin("plugin.serialization") version "1.9.22"
+    kotlin("plugin.serialization") version "2.3.20"
     id("me.champeau.jmh")
 }
 

--- a/opendc-experiments/opendc-experiments-m3sa/build.gradle.kts
+++ b/opendc-experiments/opendc-experiments-m3sa/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
     `testing-conventions`
     `jacoco-conventions`
     distribution
-    kotlin("plugin.serialization") version "1.9.22"
+    kotlin("plugin.serialization") version "2.3.20"
 }
 
 dependencies {

--- a/opendc-trace/opendc-trace-parquet/build.gradle.kts
+++ b/opendc-trace/opendc-trace-parquet/build.gradle.kts
@@ -25,7 +25,7 @@ description = "Parquet helpers for traces in OpenDC"
 // Build configuration
 plugins {
     `kotlin-library-conventions`
-    kotlin("plugin.serialization") version "1.9.22"
+    kotlin("plugin.serialization") version "2.3.20"
 }
 
 dependencies {

--- a/opendc-trace/opendc-trace-parquet/src/main/kotlin/org/opendc/trace/util/parquet/LocalParquetReader.kt
+++ b/opendc-trace/opendc-trace-parquet/src/main/kotlin/org/opendc/trace/util/parquet/LocalParquetReader.kt
@@ -121,7 +121,7 @@ public class LocalParquetReader<out T>(
      * Construct a [ParquetReader] for the specified [input] with a custom [ReadSupport].
      */
     private fun createReader(input: InputFile): ParquetReader<T> {
-        return object : ParquetReader.Builder<T>(input) {
+        return object : ParquetReader.Builder<@UnsafeVariance T>(input) {
             override fun getReadSupport(): ReadSupport<@UnsafeVariance T> = this@LocalParquetReader.readSupport
         }
             .set("parquet.strict.typing", strictTyping.toString())

--- a/opendc-web/opendc-web-client/src/main/kotlin/org/opendc/web/client/transport/HttpTransportClient.kt
+++ b/opendc-web/opendc-web-client/src/main/kotlin/org/opendc/web/client/transport/HttpTransportClient.kt
@@ -43,7 +43,7 @@ import java.nio.file.Paths
 public class HttpTransportClient(
     private val baseUrl: URI,
     private val auth: AuthController?,
-    private val client: HttpClient = HttpClient.newHttpClient(),
+    private val client: HttpClient = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build(),
 ) : TransportClient {
     /**
      * The Jackson object mapper to convert messages from/to JSON.

--- a/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/OperationalPhenomena.java
+++ b/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/OperationalPhenomena.java
@@ -22,7 +22,9 @@
 
 package org.opendc.web.proto;
 
+import java.io.Serializable;
+
 /**
  * Object describing the enabled operational phenomena for a scenario.
  */
-public record OperationalPhenomena(boolean failures, boolean interference) {}
+public record OperationalPhenomena(boolean failures, boolean interference) implements Serializable {}

--- a/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/Targets.java
+++ b/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/Targets.java
@@ -23,6 +23,7 @@
 package org.opendc.web.proto;
 
 import jakarta.validation.constraints.Min;
+import java.io.Serializable;
 import java.util.Set;
 
 /**
@@ -31,4 +32,4 @@ import java.util.Set;
  * @param metrics The selected metrics to track during simulation.
  * @param repeats The number of repetitions per scenario.
  */
-public record Targets(Set<String> metrics, @Min(1) int repeats) {}
+public record Targets(Set<String> metrics, @Min(1) int repeats) implements Serializable {}

--- a/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/Machine.java
+++ b/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/Machine.java
@@ -23,6 +23,7 @@
 package org.opendc.web.proto.topology;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 import java.util.List;
 
 /**
@@ -35,4 +36,5 @@ public record Machine(
         List<ProcessingUnit> gpus,
         @JsonProperty("memories") List<MemoryUnit> memory,
         @JsonProperty("storages") List<MemoryUnit> storage,
-        String rackId) {}
+        String rackId)
+        implements Serializable {}

--- a/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/MemoryUnit.java
+++ b/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/MemoryUnit.java
@@ -22,7 +22,10 @@
 
 package org.opendc.web.proto.topology;
 
+import java.io.Serializable;
+
 /**
  * A memory unit in a system.
  */
-public record MemoryUnit(String id, String name, double speedMbPerS, double sizeMb, double energyConsumptionW) {}
+public record MemoryUnit(String id, String name, double speedMbPerS, double sizeMb, double energyConsumptionW)
+        implements Serializable {}

--- a/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/ProcessingUnit.java
+++ b/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/ProcessingUnit.java
@@ -22,8 +22,10 @@
 
 package org.opendc.web.proto.topology;
 
+import java.io.Serializable;
+
 /**
  * A CPU model.
  */
-public record ProcessingUnit(
-        String id, String name, double clockRateMhz, int numberOfCores, double energyConsumptionW) {}
+public record ProcessingUnit(String id, String name, double clockRateMhz, int numberOfCores, double energyConsumptionW)
+        implements Serializable {}

--- a/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/Rack.java
+++ b/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/Rack.java
@@ -22,9 +22,11 @@
 
 package org.opendc.web.proto.topology;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * A rack in a datacenter.
  */
-public record Rack(String id, String name, int capacity, double powerCapacityW, List<Machine> machines) {}
+public record Rack(String id, String name, int capacity, double powerCapacityW, List<Machine> machines)
+        implements Serializable {}

--- a/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/Room.java
+++ b/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/Room.java
@@ -22,9 +22,10 @@
 
 package org.opendc.web.proto.topology;
 
+import java.io.Serializable;
 import java.util.Set;
 
 /**
  * A room in a datacenter.
  */
-public record Room(String id, String name, Set<RoomTile> tiles, String topologyId) {}
+public record Room(String id, String name, Set<RoomTile> tiles, String topologyId) implements Serializable {}

--- a/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/RoomTile.java
+++ b/opendc-web/opendc-web-proto/src/main/java/org/opendc/web/proto/topology/RoomTile.java
@@ -22,7 +22,10 @@
 
 package org.opendc.web.proto.topology;
 
+import java.io.Serializable;
+
 /**
  * A location in a room.
  */
-public record RoomTile(String id, double positionX, double positionY, Rack rack, String roomId) {}
+public record RoomTile(String id, double positionX, double positionY, Rack rack, String roomId)
+        implements Serializable {}

--- a/opendc-web/opendc-web-quarkus-deployment/src/main/java/org/opendc/web/quarkus/deployment/runner/OpenDCRunnerConfig.java
+++ b/opendc-web/opendc-web-quarkus-deployment/src/main/java/org/opendc/web/quarkus/deployment/runner/OpenDCRunnerConfig.java
@@ -22,17 +22,20 @@
 
 package org.opendc.web.quarkus.deployment.runner;
 
-import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 /**
  * Build-time configuration for the OpenDC web runner extension.
  */
-@ConfigRoot(name = "opendc-runner")
-public class OpenDCRunnerConfig {
+@ConfigMapping(prefix = "quarkus.opendc-runner")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface OpenDCRunnerConfig {
     /**
      * A flag to include the OpenDC web runner extension into the build.
      */
-    @ConfigItem(defaultValue = "true")
-    boolean include;
+    @WithDefault("true")
+    boolean include();
 }

--- a/opendc-web/opendc-web-quarkus-deployment/src/main/java/org/opendc/web/quarkus/deployment/runner/OpenDCRunnerProcessor.java
+++ b/opendc-web/opendc-web-quarkus-deployment/src/main/java/org/opendc/web/quarkus/deployment/runner/OpenDCRunnerProcessor.java
@@ -37,7 +37,6 @@ import java.util.Set;
 import java.util.function.BooleanSupplier;
 import org.opendc.trace.spi.TraceFormat;
 import org.opendc.web.quarkus.runtime.runner.OpenDCRunnerRecorder;
-import org.opendc.web.quarkus.runtime.runner.OpenDCRunnerRuntimeConfig;
 import org.opendc.web.runner.JobManager;
 import org.opendc.web.runner.OpenDCRunner;
 
@@ -84,10 +83,8 @@ public class OpenDCRunnerProcessor {
     @BuildStep(onlyIf = IsIncluded.class)
     @Record(RUNTIME_INIT)
     ServiceStartBuildItem createRunnerService(
-            OpenDCRunnerRecorder recorder,
-            OpenDCRunnerRuntimeConfig config,
-            BuildProducer<OpenDCRunnerBuildItem> runnerBuildItem) {
-        RuntimeValue<OpenDCRunner> runner = recorder.createRunner(config);
+            OpenDCRunnerRecorder recorder, BuildProducer<OpenDCRunnerBuildItem> runnerBuildItem) {
+        RuntimeValue<OpenDCRunner> runner = recorder.createRunner();
         runnerBuildItem.produce(new OpenDCRunnerBuildItem(runner));
         return new ServiceStartBuildItem("OpenDCRunnerService");
     }
@@ -101,9 +98,8 @@ public class OpenDCRunnerProcessor {
             ApplicationStartBuildItem start,
             OpenDCRunnerBuildItem runnerBuildItem,
             OpenDCRunnerRecorder recorder,
-            OpenDCRunnerRuntimeConfig config,
             ShutdownContextBuildItem shutdownContextBuildItem) {
-        recorder.startRunner(runnerBuildItem.getRunner(), config, shutdownContextBuildItem);
+        recorder.startRunner(runnerBuildItem.getRunner(), shutdownContextBuildItem);
     }
 
     /**
@@ -114,7 +110,7 @@ public class OpenDCRunnerProcessor {
 
         @Override
         public boolean getAsBoolean() {
-            return config.include;
+            return config.include();
         }
     }
 }

--- a/opendc-web/opendc-web-quarkus-deployment/src/main/java/org/opendc/web/quarkus/deployment/ui/OpenDCUiProcessor.java
+++ b/opendc-web/opendc-web-quarkus-deployment/src/main/java/org/opendc/web/quarkus/deployment/ui/OpenDCUiProcessor.java
@@ -28,7 +28,6 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
 import io.quarkus.vertx.http.deployment.RouteBuildItem;
-import org.opendc.web.quarkus.runtime.ui.OpenDCUiConfig;
 import org.opendc.web.quarkus.runtime.ui.OpenDCUiRecorder;
 
 /**
@@ -43,15 +42,14 @@ public class OpenDCUiProcessor {
     public RouteBuildItem registerConfigHandler(
             OpenDCUiRecorder openDCUiRecorder,
             BuildProducer<RouteBuildItem> routes,
-            HttpRootPathBuildItem httpRootPathBuildItem,
-            OpenDCUiConfig openDCUiConfig) {
+            HttpRootPathBuildItem httpRootPathBuildItem) {
 
         String basePath = httpRootPathBuildItem.getRootPath();
 
         return httpRootPathBuildItem
                 .routeBuilder()
                 .route(basePath + "/__ENV.js")
-                .handler(openDCUiRecorder.configHandler(openDCUiConfig))
+                .handler(openDCUiRecorder.configHandler())
                 .build();
     }
 }

--- a/opendc-web/opendc-web-quarkus-deployment/src/main/java/org/opendc/web/quarkus/deployment/ui/QuinoaNextRoutingProcessor.java
+++ b/opendc-web/opendc-web-quarkus-deployment/src/main/java/org/opendc/web/quarkus/deployment/ui/QuinoaNextRoutingProcessor.java
@@ -125,7 +125,7 @@ public class QuinoaNextRoutingProcessor {
             BuiltResourcesBuildItem uiResources,
             NextRouteManifestBuildItem routeManifestBuildItem) {
 
-        if (uiResources.getNames().isEmpty()) {
+        if (uiResources.resources().isEmpty()) {
             return;
         }
 

--- a/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/runner/OpenDCRunnerRecorder.java
+++ b/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/runner/OpenDCRunnerRecorder.java
@@ -25,8 +25,10 @@ package org.opendc.web.quarkus.runtime.runner;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.ShutdownContext;
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.SmallRyeConfig;
 import jakarta.enterprise.inject.spi.CDI;
 import java.io.File;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 import org.opendc.web.runner.JobManager;
 import org.opendc.web.runner.OpenDCRunner;
@@ -41,8 +43,12 @@ public class OpenDCRunnerRecorder {
     /**
      * Helper method to create an {@link OpenDCRunner} instance.
      */
-    public RuntimeValue<OpenDCRunner> createRunner(OpenDCRunnerRuntimeConfig config) {
-        int parallelism = config.parallelism;
+    public RuntimeValue<OpenDCRunner> createRunner() {
+        OpenDCRunnerRuntimeConfig config = ConfigProvider.getConfig()
+                .unwrap(SmallRyeConfig.class)
+                .getConfigMapping(OpenDCRunnerRuntimeConfig.class);
+
+        int parallelism = config.parallelism();
         if (parallelism < 0) {
             throw new IllegalArgumentException("Parallelism must be non-negative");
         } else if (parallelism == 0) {
@@ -52,11 +58,11 @@ public class OpenDCRunnerRecorder {
         JobManager manager = CDI.current().select(JobManager.class).get();
         OpenDCRunner runner = new OpenDCRunner(
                 manager,
-                new File(config.tracePath),
+                new File(config.tracePath()),
                 parallelism,
-                config.jobTimeout,
-                config.pollInterval,
-                config.heartbeatInterval);
+                config.jobTimeout(),
+                config.pollInterval(),
+                config.heartbeatInterval());
 
         return new RuntimeValue<>(runner);
     }
@@ -64,10 +70,13 @@ public class OpenDCRunnerRecorder {
     /**
      * Helper method to start the OpenDC runner service.
      */
-    public void startRunner(
-            RuntimeValue<OpenDCRunner> runner, OpenDCRunnerRuntimeConfig config, ShutdownContext shutdownContext) {
-        if (config.enable) {
-            LOGGER.info("Starting OpenDC Runner in background (polling every " + config.pollInterval + ")");
+    public void startRunner(RuntimeValue<OpenDCRunner> runner, ShutdownContext shutdownContext) {
+        OpenDCRunnerRuntimeConfig config = ConfigProvider.getConfig()
+                .unwrap(SmallRyeConfig.class)
+                .getConfigMapping(OpenDCRunnerRuntimeConfig.class);
+
+        if (config.enable()) {
+            LOGGER.info("Starting OpenDC Runner in background (polling every " + config.pollInterval() + ")");
 
             Thread thread = new Thread(runner.getValue());
             thread.setName("opendc-runner");

--- a/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/runner/OpenDCRunnerRuntimeConfig.java
+++ b/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/runner/OpenDCRunnerRuntimeConfig.java
@@ -22,49 +22,51 @@
 
 package org.opendc.web.quarkus.runtime.runner;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 import java.time.Duration;
 
 /**
  * Configuration for the OpenDC web runner.
  */
-@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "opendc-runner")
-public class OpenDCRunnerRuntimeConfig {
+@ConfigMapping(prefix = "quarkus.opendc-runner")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface OpenDCRunnerRuntimeConfig {
     /**
      * Flag to indicate whether the runner should be enabled.
      */
-    @ConfigItem(defaultValue = "true")
-    public boolean enable;
+    @WithDefault("true")
+    boolean enable();
 
     /**
      * The path where the workload traces are located.
      */
-    @ConfigItem(defaultValue = "traces")
-    public String tracePath;
+    @WithDefault("traces")
+    String tracePath();
 
     /**
      * The number of concurrent simulations
      */
-    @ConfigItem(defaultValue = "1")
-    public int parallelism;
+    @WithDefault("1")
+    int parallelism();
 
     /**
      * The maximum duration of a job.
      */
-    @ConfigItem(defaultValue = "10m")
-    public Duration jobTimeout;
+    @WithDefault("10m")
+    Duration jobTimeout();
 
     /**
      * The interval between successive polls to the API.
      */
-    @ConfigItem(defaultValue = "30s")
-    public Duration pollInterval;
+    @WithDefault("30s")
+    Duration pollInterval();
 
     /**
      * The interval between successive heartbeats to the API.
      */
-    @ConfigItem(defaultValue = "1m")
-    public Duration heartbeatInterval;
+    @WithDefault("1m")
+    Duration heartbeatInterval();
 }

--- a/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/ui/AuthConfiguration.java
+++ b/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/ui/AuthConfiguration.java
@@ -22,30 +22,24 @@
 
 package org.opendc.web.quarkus.runtime.ui;
 
-import io.quarkus.runtime.annotations.ConfigGroup;
-import io.quarkus.runtime.annotations.ConfigItem;
 import java.util.Optional;
 
 /**
  * Auth configuration for the OpenDC UI extension.
  */
-@ConfigGroup
-public class AuthConfiguration {
+public interface AuthConfiguration {
     /**
      * The authentication domain.
      */
-    @ConfigItem
-    Optional<String> domain;
+    Optional<String> domain();
 
     /**
      * The client identifier used by the OpenDC web ui.
      */
-    @ConfigItem
-    Optional<String> clientId;
+    Optional<String> clientId();
 
     /**
      * The audience of the OpenDC API.
      */
-    @ConfigItem
-    Optional<String> audience;
+    Optional<String> audience();
 }

--- a/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/ui/OpenDCUiConfig.java
+++ b/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/ui/OpenDCUiConfig.java
@@ -22,30 +22,31 @@
 
 package org.opendc.web.quarkus.runtime.ui;
 
-import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 import java.util.Optional;
 
 /**
  * Configuration for the OpenDC web UI.
  */
-@ConfigRoot(phase = ConfigPhase.RUN_TIME, name = "opendc-ui")
-public class OpenDCUiConfig {
+@ConfigMapping(prefix = "quarkus.opendc-ui")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface OpenDCUiConfig {
     /**
      * The base URL of the OpenDC API.
      */
-    @ConfigItem(defaultValue = "/api")
-    String apiBaseUrl;
+    @WithDefault("/api")
+    String apiBaseUrl();
 
     /**
      * Configuration properties for web UI authentication.
      */
-    AuthConfiguration auth;
+    AuthConfiguration auth();
 
     /**
      * Sentry DSN.
      */
-    @ConfigItem
-    Optional<String> sentryDsn;
+    Optional<String> sentryDsn();
 }

--- a/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/ui/OpenDCUiRecorder.java
+++ b/opendc-web/opendc-web-quarkus/src/main/java/org/opendc/web/quarkus/runtime/ui/OpenDCUiRecorder.java
@@ -25,13 +25,18 @@ package org.opendc.web.quarkus.runtime.ui;
 import static io.vertx.ext.web.handler.StaticHandler.DEFAULT_MAX_AGE_SECONDS;
 
 import io.quarkus.runtime.annotations.Recorder;
+import io.smallrye.config.SmallRyeConfig;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-import io.vertx.ext.web.impl.Utils;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 /**
  * Recorder class for the OpenDC web UI.
@@ -41,7 +46,7 @@ public class OpenDCUiRecorder {
     /**
      * Construct a {@link Handler} for serving the configuration of the OpenDC web UI.
      */
-    public Handler<RoutingContext> configHandler(OpenDCUiConfig config) {
+    public Handler<RoutingContext> configHandler() {
         return (event) -> {
             HttpServerRequest request = event.request();
             if (request.method() != HttpMethod.GET && request.method() != HttpMethod.HEAD) {
@@ -49,11 +54,16 @@ public class OpenDCUiRecorder {
                 return;
             }
 
+            OpenDCUiConfig config =
+                    ConfigProvider.getConfig().unwrap(SmallRyeConfig.class).getConfigMapping(OpenDCUiConfig.class);
+            String dateHeader = DateTimeFormatter.RFC_1123_DATE_TIME.format(
+                    ZonedDateTime.ofInstant(Instant.ofEpochMilli(System.currentTimeMillis()), ZoneOffset.UTC));
+
             event.response()
                     .setStatusCode(200)
                     .putHeader(HttpHeaders.CONTENT_TYPE, "text/javascript")
                     .putHeader(HttpHeaders.CACHE_CONTROL, "public, immutable, max-age=" + DEFAULT_MAX_AGE_SECONDS)
-                    .putHeader(HttpHeaders.DATE, Utils.formatRFC1123DateTime(System.currentTimeMillis()))
+                    .putHeader(HttpHeaders.DATE, dateHeader)
                     .end(OpenDCUiRecorder.serializeConfig(config));
         };
     }
@@ -65,11 +75,11 @@ public class OpenDCUiRecorder {
      * @return JS serialized version of the OpenDC web UI config.
      */
     private static String serializeConfig(OpenDCUiConfig config) {
-        JsonObject configJson = JsonObject.of("NEXT_PUBLIC_API_BASE_URL", config.apiBaseUrl);
-        config.auth.domain.ifPresent(s -> configJson.put("NEXT_PUBLIC_AUTH0_DOMAIN", s));
-        config.auth.clientId.ifPresent(s -> configJson.put("NEXT_PUBLIC_AUTH0_CLIENT_ID", s));
-        config.auth.audience.ifPresent(s -> configJson.put("NEXT_PUBLIC_AUTH0_AUDIENCE", s));
-        config.sentryDsn.ifPresent(s -> configJson.put("NEXT_PUBLIC_SENTRY_DSN", s));
+        JsonObject configJson = JsonObject.of("NEXT_PUBLIC_API_BASE_URL", config.apiBaseUrl());
+        config.auth().domain().ifPresent(s -> configJson.put("NEXT_PUBLIC_AUTH0_DOMAIN", s));
+        config.auth().clientId().ifPresent(s -> configJson.put("NEXT_PUBLIC_AUTH0_CLIENT_ID", s));
+        config.auth().audience().ifPresent(s -> configJson.put("NEXT_PUBLIC_AUTH0_AUDIENCE", s));
+        config.sentryDsn().ifPresent(s -> configJson.put("NEXT_PUBLIC_SENTRY_DSN", s));
 
         return "window.__ENV = " + configJson.encode() + ";";
     }

--- a/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/OpenDCRunner.kt
+++ b/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/OpenDCRunner.kt
@@ -48,6 +48,7 @@ import org.opendc.web.proto.runner.Topology
 import org.opendc.web.runner.internal.ReportCollector
 import org.opendc.web.runner.internal.WebComputeMonitor
 import java.io.File
+import java.io.IOException
 import java.time.Duration
 import java.time.Instant
 import java.time.temporal.ChronoUnit
@@ -107,26 +108,12 @@ public class OpenDCRunner(
      */
     override fun run() {
         try {
-            while (true) {
-                val job = manager.findNext()
-                if (job == null) {
+            while (true)
+                if (pollOnce()) {
                     Thread.sleep(pollInterval.toMillis())
-                    continue
                 }
-
-                val id = job.id
-
-                logger.info { "Found queued job $id: attempting to claim" }
-
-                if (!manager.claim(id)) {
-                    logger.info { "Failed to claim scenario" }
-                    continue
-                }
-
-                pool.submit(JobAction(job))
-            }
         } catch (_: InterruptedException) {
-            // Gracefully exit when the thread is interrupted
+            logger.warn { "Runner process interrupted, shutting down" }
         } finally {
             workloadLoader.reset()
 
@@ -135,6 +122,37 @@ public class OpenDCRunner(
 
             pool.awaitTermination(5, TimeUnit.SECONDS)
         }
+    }
+
+    /**
+     * Attempt to find and dispatch one pending job.
+     *
+     * Returns `true` if the caller should sleep for [pollInterval] before the next attempt (no work
+     * was found, or a transient error occurred), `false` to poll again immediately.
+     */
+    private fun pollOnce(): Boolean {
+        val job =
+            try {
+                manager.findNext()
+            } catch (e: IOException) {
+                logger.warn(e) { "Transient error polling for jobs; retrying after poll interval" }
+                return true
+            }
+
+        logger.info { "Polling for jobs: found ${if (job == null) "no" else "job ${job.id}"} to execute" }
+        if (job == null) return true
+
+        val id = job.id
+
+        logger.info { "Found queued job $id: attempting to claim" }
+
+        if (!manager.claim(id)) {
+            logger.info { "Failed to claim scenario" }
+            return false
+        }
+
+        pool.submit(JobAction(job))
+        return false
     }
 
     /**
@@ -166,6 +184,7 @@ public class OpenDCRunner(
 
             try {
                 val topology = convertTopology(scenario.topology)
+                require(topology.isNotEmpty()) { "Topology '${scenario.topology.name}' has no hosts configured" }
                 val jobs =
                     (0 until scenario.portfolio.targets.repeats).map { repeat ->
                         SimulationTask(
@@ -213,8 +232,12 @@ public class OpenDCRunner(
                     ),
                     report,
                 )
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
                 reportCollector.detach()
+
+                // Cancel the heartbeat first so it cannot re-interrupt this thread after
+                // Thread.interrupted() clears the flag below.
+                heartbeat.cancel(true)
 
                 val duration = startTime.secondsSince()
 
@@ -225,7 +248,7 @@ public class OpenDCRunner(
                     }
 
                 val errorInfo =
-                    if (Thread.interrupted()) {
+                    if (Thread.interrupted() || e is InterruptedException) {
                         logger.info { "Simulation job $id exceeded time limit ($duration seconds)" }
                         Report.ErrorInfo("Simulation exceeded time limit", "TIMEOUT", null)
                     } else {
@@ -236,7 +259,6 @@ public class OpenDCRunner(
                 val report = reportCollector.collect(duration, waitTime, job.createdAt, job.startedAt, errorInfo)
 
                 try {
-                    heartbeat.cancel(true)
                     manager.fail(id, duration, report)
                 } catch (e: Throwable) {
                     logger.error(e) { "Failed to update job" }

--- a/opendc-web/opendc-web-server/build.gradle.kts
+++ b/opendc-web/opendc-web-server/build.gradle.kts
@@ -28,6 +28,16 @@ plugins {
     distribution
 }
 
+// This Quarkus application uses JBoss LogManager for logging. The OpenDC simulation modules route
+// SLF4J through Log4j2 and expose the Log4j2 SLF4J binding (log4j-slf4j2-impl) as an api dependency,
+// so it leaks transitively into this server, leaving SLF4J with two competing providers. Whichever
+// one wins is classpath-order dependent; when Log4j2 wins, its Interpolator boots inside Quarkus'
+// isolated classloader and fails to load its lookup plugins (ClassCastException against StrLookup).
+// Drop the Log4j2 SLF4J binding here so SLF4J binds deterministically to Quarkus' JBoss LogManager.
+configurations.all {
+    exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j2-impl")
+}
+
 dependencies {
     implementation(enforcedPlatform(libs.quarkus.bom))
 

--- a/opendc-web/opendc-web-server/src/main/resources/application-dev.properties
+++ b/opendc-web/opendc-web-server/src/main/resources/application-dev.properties
@@ -33,7 +33,7 @@ quarkus.oidc.enabled=false
 opendc.security.enabled=false
 
 # Create new tables and fill them
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=load_data.sql
 
 # Quinoa

--- a/opendc-web/opendc-web-server/src/main/resources/application-docker.properties
+++ b/opendc-web/opendc-web-server/src/main/resources/application-docker.properties
@@ -41,7 +41,7 @@ quarkus.swagger-ui.oauth-client-id=${OPENDC_AUTH0_CLIENT_ID}
 quarkus.swagger-ui.oauth-additional-query-string-params={"audience":"${OPENDC_AUTH0_AUDIENCE:https://opendc.org}"}
 
 # Enable the settings below if you want to test the docker-compose deployment locally
-#quarkus.hibernate-orm.database.generation=drop-and-create
+#quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.resteasy.path=/api
 quarkus.oidc.enabled=true
 #opendc.security.enabled=false

--- a/opendc-web/opendc-web-server/src/main/resources/application-test.properties
+++ b/opendc-web/opendc-web-server/src/main/resources/application-test.properties
@@ -25,6 +25,7 @@ quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1;INIT=CREATE TY
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.hibernate-orm.log.sql=true
 quarkus.flyway.clean-at-start=true
+quarkus.flyway.clean-disabled=false
 quarkus.flyway.locations=db/testing
 
 # Disable security
@@ -34,10 +35,9 @@ quarkus.oidc.enabled=false
 quarkus.smallrye-openapi.enable=false
 quarkus.swagger-ui.enable=false
 
-# Disable OpenDC web UI and runner
-quarkus.opendc-ui.include=false
+# Disable OpenDC runner
 quarkus.opendc-runner.include=false
 
 # Create new tables and fill them
-quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.schema-management.strategy=drop-and-create
 quarkus.hibernate-orm.sql-load-script=load_data.sql

--- a/opendc-web/opendc-web-server/src/main/resources/application.properties
+++ b/opendc-web/opendc-web-server/src/main/resources/application.properties
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 # Enable CORS
-quarkus.http.cors=true
+quarkus.http.cors.enabled=true
 quarkus.http.cors.origins=http://localhost:3000,https://opendc.org
 
 # Quinoa

--- a/opendc-web/opendc-web-server/src/main/webui/package.json
+++ b/opendc-web/opendc-web-server/src/main/webui/package.json
@@ -16,6 +16,7 @@
     "author": "OpenDC Maintainers <opendc@atlarge-research.com>",
     "license": "MIT",
     "private": true,
+    "output": "export",
     "dependencies": {
         "@auth0/auth0-react": "^1.12.1",
         "@patternfly/react-charts": "^6.94.18",


### PR DESCRIPTION
## Summary

Upgrade Kotlin from 1.9.22 to 2.3.20 and Quarkus from 3.8.0 to 3.33.1 LTS, along with all required migration changes across build tooling, configuration, the opendc-web runtime extension, and the opendc-web-runner. 

I think we should aim to have this change in the main branch ASAP for future branches to develop using newer APIs, therefore reducing any other work needed to migrate legacy/deprecated code.

## Implementation Notes

- **Kotlin 1.9.22 to 2.3.20**: Removed now-redundant explicit-API settings from `kotlin-conventions.gradle.kts`; updated `LocalParquetReader.kt` for Kotlin 2.x API compatibility.
- **Quarkus 3.8.0 to 3.33.1 LTS**: Quarkus 3.8 was past its support window. 3.33 LTS is the baseline required for the upcoming horizontal-scaling work (S3/MinIO export externalization, OpenTelemetry-traced `@Scheduled` reaper, `@PermissionsAllowed` for per-runner identity) for Daniel Halasz's project and potential future work.
- **Gradle 8.10 to 8.14.4** (breaking): Updated to satisfy the Quarkus 3.33 build requirements.
- **log4j 2.23.0 to 2.25.3** (breaking): Required for Quarkus 3.33 compatibility; also resolves CVEs present in the 2.23–2.24 range.
- **hypersistence-utils-hibernate-63 3.7.3 to hibernate-71 3.15.2**: Follows the Hibernate ORM 6.x -> 7.1 upgrade bundled in Quarkus 3.33. All `opendc-web-proto` records now implement `Serializable` as enforced by Hibernate 7.1's stricter entity-type checks.
- **SmallRye Config migration**: `OpenDCRunnerRuntimeConfig` and `OpenDCUiConfig` migrated from the deprecated `@ConfigRoot` annotation model to the `@ConfigMapping` interface model.
-  **Quinoa 2.3.4 to 2.8.1** (breaking): SPA routing configuration moved from `application.properties` to `"output": "export"` in the webui `package.json`. `QuinoaNextRoutingProcessor` updated accordingly.
- **vert.x deprecation fix**: Replaced `Utils#formatRFC1123DateTime` with `DateTimeFormatter.RFC_1123_DATE_TIME` in `OpenDCUiRecorder`.
- **OpenDC Web Runner stability fixes**: Forced HTTP/1.1 in `HttpTransportClient` (Quarkus dev server does not support h2c upgrade); extracted `pollOnce()` in `OpenDCRunner` with transient-`IOException` sleep-and-retry; changed catch from `Exception` to `Throwable` to close a re-interrupt race; added a topology empty-check to surface misconfigured scenarios early.

## External Dependencies

- Kotlin 2.3.20
- Quarkus 3.33.1 LTS (Hibernate ORM 7.1, vert.x 5.x, SmallRye Config 3.x)
- Quinoa 2.8.1
- hypersistence-utils-hibernate-71 3.15.2
- log4j 2.25.3
- Gradle 8.14.4

## Breaking API Changes

- **Gradle wrapper 8.10 to 8.14.4**: The new wrapper must be re-downloaded by everyone executing `gradlew`.
- **log4j 2.25.3**: Any direct log4j dependency outside Quarkus must be aligned to this version. This should not be a problem (logging still works fine), but may be something worth keeping an eye on.