### PR TITLE
Added proper Python setup for M3SA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
-
-      - name: Install M3SA Python requirements
-        run: pip install -r opendc-experiments/opendc-experiments-m3sa/src/main/python/requirements.txt
       - name: Build with Gradle
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
+
+      - name: Install M3SA Python requirements
+        run: pip install -r opendc-experiments/opendc-experiments-m3sa/src/main/python/requirements.txt
       - name: Build with Gradle
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
+++ b/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
@@ -20,6 +20,7 @@
  * SOFTWARE.
  */
 
+import java.nio.file.Files
 import java.nio.file.Paths
 
 /**
@@ -32,14 +33,28 @@ public fun m3saAnalyze(
     m3saSetupPath: String,
     m3saExecPath: String,
 ) {
+    // script to run
     val scriptPath =
-        Paths.get(m3saExecPath, "m3sa")
+        Paths.get(m3saExecPath, "main.py")
             .toAbsolutePath()
             .normalize()
             .toString()
 
+    // look for venv python; if missing, use system python3
+    val venvPython =
+        Paths.get(m3saExecPath, "venv", "bin", "python3")
+            .toAbsolutePath()
+            .normalize()
+    val pythonBin =
+        if (Files.isRegularFile(venvPython) && Files.isExecutable(venvPython)) {
+            venvPython.toString()
+        } else {
+            "python3" // fallback
+        }
+
     val process =
         ProcessBuilder(
+            pythonBin,
             scriptPath,
             m3saSetupPath,
             "$outputFolderPath/raw-output",

--- a/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
+++ b/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 AtLarge Research
+ * Copyright (c) 2026 AtLarge Research
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,7 @@
  * SOFTWARE.
  */
 
-import java.nio.file.Files
+package org.opendc.experiments.m3sa
 import java.nio.file.Paths
 
 /**
@@ -33,29 +33,29 @@ public fun m3saAnalyze(
     m3saSetupPath: String,
     m3saExecPath: String,
 ) {
-    // script to run
-    val scriptPath =
-        Paths.get(m3saExecPath, "main.py")
-            .toAbsolutePath()
-            .normalize()
-            .toString()
-
-    // look for venv python; if missing, use system python3
-    val venvPython =
-        Paths.get(m3saExecPath, "venv", "bin", "python3")
-            .toAbsolutePath()
-            .normalize()
-    val pythonBin =
-        if (Files.isRegularFile(venvPython) && Files.isExecutable(venvPython)) {
-            venvPython.toString()
+    val isWindows: Boolean =
+        System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+    val command: List<String> =
+        if (isWindows) {
+            listOf(
+                "python",
+                Paths.get(m3saExecPath, "main.py")
+                    .toAbsolutePath()
+                    .normalize()
+                    .toString(),
+            )
         } else {
-            "python3" // fallback
+            listOf(
+                Paths.get(m3saExecPath, "m3sa")
+                    .toAbsolutePath()
+                    .normalize()
+                    .toString(),
+            )
         }
 
     val process =
         ProcessBuilder(
-            pythonBin,
-            scriptPath,
+            *command.toTypedArray(),
             m3saSetupPath,
             "$outputFolderPath/raw-output",
             "-o",

--- a/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
+++ b/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/M3SAAnalyzer.kt
@@ -20,7 +20,6 @@
  * SOFTWARE.
  */
 
-import java.nio.file.Files
 import java.nio.file.Paths
 
 /**
@@ -33,28 +32,14 @@ public fun m3saAnalyze(
     m3saSetupPath: String,
     m3saExecPath: String,
 ) {
-    // script to run
     val scriptPath =
-        Paths.get(m3saExecPath, "main.py")
+        Paths.get(m3saExecPath, "m3sa")
             .toAbsolutePath()
             .normalize()
             .toString()
 
-    // look for venv python; if missing, use system python3
-    val venvPython =
-        Paths.get(m3saExecPath, "venv", "bin", "python3")
-            .toAbsolutePath()
-            .normalize()
-    val pythonBin =
-        if (Files.isRegularFile(venvPython) && Files.isExecutable(venvPython)) {
-            venvPython.toString()
-        } else {
-            "python3" // fallback
-        }
-
     val process =
         ProcessBuilder(
-            pythonBin,
             scriptPath,
             m3saSetupPath,
             "$outputFolderPath/raw-output",

--- a/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/runner/M3SACli.kt
+++ b/opendc-experiments/opendc-experiments-m3sa/src/main/kotlin/org/opendc/experiments/m3sa/runner/M3SACli.kt
@@ -30,8 +30,8 @@ import com.github.ajalt.clikt.parameters.options.defaultLazy
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.file
 import com.github.ajalt.clikt.parameters.types.int
-import m3saAnalyze
 import org.opendc.experiments.base.experiment.getExperiment
+import org.opendc.experiments.m3sa.m3saAnalyze
 import org.opendc.experiments.m3sa.scenario.getOutputFolder
 import java.io.File
 

--- a/opendc-experiments/opendc-experiments-m3sa/src/main/python/m3sa
+++ b/opendc-experiments/opendc-experiments-m3sa/src/main/python/m3sa
@@ -9,11 +9,11 @@ VENV_PATH="$SRC_PATH/venv"
 
 if [ ! -d "$VENV_PATH" ]; then
     python3 -m venv "$VENV_PATH" || exit 1
+    pip install --upgrade pip || exit 1
+    pip install -r "$SRC_PATH/requirements.txt" || exit 1
 fi
 
 . "$VENV_PATH/bin/activate"
-pip install --upgrade pip || exit 1
-pip install -r "$SRC_PATH/requirements.txt" || exit 1
 python3 "$SRC_PATH/main.py" "$@"
 
 

--- a/opendc-experiments/opendc-experiments-m3sa/src/main/python/m3sa
+++ b/opendc-experiments/opendc-experiments-m3sa/src/main/python/m3sa
@@ -9,11 +9,11 @@ VENV_PATH="$SRC_PATH/venv"
 
 if [ ! -d "$VENV_PATH" ]; then
     python3 -m venv "$VENV_PATH" || exit 1
-    pip install --upgrade pip || exit 1
-    pip install -r "$SRC_PATH/requirements.txt" || exit 1
 fi
 
 . "$VENV_PATH/bin/activate"
+pip install --upgrade pip || exit 1
+pip install -r "$SRC_PATH/requirements.txt" || exit 1
 python3 "$SRC_PATH/main.py" "$@"
 
 


### PR DESCRIPTION
## Summary

This PR fixes M3SARunnerTest not running in the local environment unless manually initializing the venv environment or manually installing `opendc-experiments/opendc-experiments-m3sa/src/main/python/requirements.txt`.
