### PR TITLE
Updated JSON readers to ignore unknown keys

### DIFF
--- a/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/TopologyFactories.kt
+++ b/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/TopologyFactories.kt
@@ -79,15 +79,21 @@ private fun createUniqueName(
 /**
  * Construct a topology from the specified [pathToFile].
  */
-public fun clusterTopology(pathToFile: String): List<ClusterSpec> {
-    return clusterTopology(File(pathToFile))
+public fun clusterTopology(
+    pathToFile: String,
+    strictReader: Boolean,
+): List<ClusterSpec> {
+    return clusterTopology(File(pathToFile), strictReader)
 }
 
 /**
  * Construct a topology from the specified [file].
  */
-public fun clusterTopology(file: File): List<ClusterSpec> {
-    val topology = reader.read(file)
+public fun clusterTopology(
+    file: File,
+    strictReader: Boolean,
+): List<ClusterSpec> {
+    val topology = reader.read(file, strictReader)
     return topology.toClusterSpec()
 }
 

--- a/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/TopologyReader.kt
+++ b/opendc-compute/opendc-compute-topology/src/main/kotlin/org/opendc/compute/topology/TopologyReader.kt
@@ -22,9 +22,9 @@
 
 package org.opendc.compute.topology
 
-import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.decodeFromStream
+import org.opendc.common.logger.logger
 import org.opendc.compute.topology.specs.TopologySpec
 import java.io.File
 import java.io.InputStream
@@ -35,20 +35,48 @@ import kotlin.io.path.inputStream
  * A helper class for reading a topology specification file.
  */
 public class TopologyReader {
-    public fun read(path: Path): TopologySpec {
-        return read(path.inputStream())
-    }
+    private val jsonReader = Json { ignoreUnknownKeys = true }
+    private val strictJsonReader = Json { ignoreUnknownKeys = false }
 
-    public fun read(file: File): TopologySpec {
-        return read(file.inputStream())
-    }
+    public fun read(
+        path: Path,
+        strictReader: Boolean = false,
+    ): TopologySpec = read(path.inputStream(), strictReader)
+
+    public fun read(
+        file: File,
+        strictReader: Boolean = false,
+    ): TopologySpec = read(file.inputStream(), strictReader)
 
     /**
      * Read the specified [input].
      */
-    @OptIn(ExperimentalSerializationApi::class)
-    public fun read(input: InputStream): TopologySpec {
-        val obj = Json.decodeFromStream<TopologySpec>(input)
-        return obj
+    public fun read(
+        input: InputStream,
+        strictReader: Boolean = false,
+    ): TopologySpec {
+        val text = input.bufferedReader().use { it.readText() }
+
+        if (strictReader) {
+            return strictJsonReader.decodeFromString<TopologySpec>(text)
+        }
+
+        val topology = jsonReader.decodeFromString<TopologySpec>(text)
+
+        // [jsonReader] ignores unknown keys, so typos and stale fields would otherwise pass silently.
+        // Decode once more with a strict reader to surface them: the two readers differ only in
+        // [JsonBuilder.ignoreUnknownKeys], and the lenient decode above already succeeded, so any
+        // failure here can only be caused by an unknown key that is being ignored.
+        try {
+            strictJsonReader.decodeFromString<TopologySpec>(text)
+        } catch (e: SerializationException) {
+            LOG.warn("The topology file contains an unknown key that is ignored: ${e.message?.substringBefore('\n')}")
+        }
+
+        return topology
+    }
+
+    private companion object {
+        private val LOG by logger("org.opendc.compute.topology.TopologyReader")
     }
 }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/ExperimentFactories.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/ExperimentFactories.kt
@@ -34,8 +34,11 @@ private val experimentWriter = ExperimentWriter()
  * @param filePath The path to the file containing the scenario specifications.
  * @return A list of Scenarios.
  */
-public fun getScenarios(filePath: String): List<Scenario> {
-    return getScenarios(File(filePath))
+public fun getScenarios(
+    filePath: String,
+    strictReader: Boolean = false,
+): List<Scenario> {
+    return getScenarios(File(filePath), strictReader)
 }
 
 /**
@@ -44,8 +47,11 @@ public fun getScenarios(filePath: String): List<Scenario> {
  * @param file The file containing the scenario specifications.
  * @return A list of Scenarios.
  */
-public fun getScenarios(file: File): List<Scenario> {
-    return getScenarios(experimentReader.read(file))
+public fun getScenarios(
+    file: File,
+    strictReader: Boolean = false,
+): List<Scenario> {
+    return getScenarios(experimentReader.read(file, strictReader))
 }
 
 /**

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/ExperimentReader.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/experiment/ExperimentReader.kt
@@ -22,9 +22,9 @@
 
 package org.opendc.experiments.base.experiment
 
-import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.decodeFromStream
+import org.opendc.common.logger.logger
 import org.opendc.compute.simulator.telemetry.parquet.ComputeExportConfig
 import org.opendc.experiments.base.experiment.specs.ExperimentSpec
 import java.io.File
@@ -33,24 +33,56 @@ import java.nio.file.Path
 import kotlin.io.path.inputStream
 
 public class ExperimentReader {
-    private val jsonReader = Json
+    private val jsonReader = Json { ignoreUnknownKeys = true }
+    private val strictJsonReader = Json { ignoreUnknownKeys = false }
 
-    public fun read(file: File): ExperimentSpec = read(file.inputStream())
+    public fun read(
+        file: File,
+        strictReader: Boolean = false,
+    ): ExperimentSpec = read(file.inputStream(), strictReader)
 
-    public fun read(path: Path): ExperimentSpec = read(path.inputStream())
+    public fun read(
+        path: Path,
+        strictReader: Boolean = false,
+    ): ExperimentSpec = read(path.inputStream(), strictReader)
 
     /**
      * Read the specified [input].
      */
-    @OptIn(ExperimentalSerializationApi::class)
-    public fun read(input: InputStream): ExperimentSpec {
+    public fun read(
+        input: InputStream,
+        strictReader: Boolean = false,
+    ): ExperimentSpec {
         // Loads the default parquet output fields,
         // so that they can be deserialized
         ComputeExportConfig.loadDfltColumns()
 
-        val experiment = jsonReader.decodeFromStream<ExperimentSpec>(input)
+        val text = input.bufferedReader().use { it.readText() }
+
+        if (strictReader) {
+            val experiment = strictJsonReader.decodeFromString<ExperimentSpec>(text)
+            experiment.validate()
+            return experiment
+        }
+
+        val experiment = jsonReader.decodeFromString<ExperimentSpec>(text)
+
+        // [jsonReader] ignores unknown keys, so typos and stale fields would otherwise pass silently.
+        // Decode once more with a strict reader to surface them: the two readers differ only in
+        // [JsonBuilder.ignoreUnknownKeys], and the lenient decode above already succeeded, so any
+        // failure here can only be caused by an unknown key that is being ignored.
+        try {
+            strictJsonReader.decodeFromString<ExperimentSpec>(text)
+        } catch (e: SerializationException) {
+            LOG.warn("The experiment file contains an unknown key that is ignored: ${e.message?.substringBefore('\n')}")
+        }
+
         experiment.validate()
 
         return experiment
+    }
+
+    private companion object {
+        private val LOG by logger("org.opendc.experiments.base.experiment.ExperimentReader")
     }
 }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ExperimentCli.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ExperimentCli.kt
@@ -26,6 +26,7 @@ package org.opendc.experiments.base.runner
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.defaultLazy
+import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.file
 import org.opendc.experiments.base.experiment.getScenarios
@@ -47,8 +48,15 @@ internal class ExperimentCommand : CliktCommand(name = "experiment") {
         .file(canBeDir = false, canBeFile = true)
         .defaultLazy { File("resources/experiment.json") }
 
+    /**
+     * Use a strict JSON reader.
+     * If False, unknown parameters are ignored.
+     * If True, unknown parameters will throw an error.
+     */
+    private val strictReader by option("-strict", help = "strict").flag(default = false)
+
     override fun run() {
-        val experiment = getScenarios(experimentPath)
-        runExperiment(experiment)
+        val experiment = getScenarios(experimentPath, strictReader)
+        runExperiment(experiment, strictReader)
     }
 }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ExperimentRunner.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ExperimentRunner.kt
@@ -31,7 +31,10 @@ import org.opendc.experiments.base.experiment.Scenario
  *
  * @param experiment The scenarios to run
  */
-public fun runExperiment(experiment: List<Scenario>) {
+public fun runExperiment(
+    experiment: List<Scenario>,
+    strictReader: Boolean = false,
+) {
     val ansiReset = "\u001B[0m"
     val ansiGreen = "\u001B[32m"
     val ansiBlue = "\u001B[34m"
@@ -52,7 +55,7 @@ public fun runExperiment(experiment: List<Scenario>) {
 
         for (seed in 0..<scenario.runs) {
             println("$ansiBlue Starting seed: $seed $ansiReset")
-            runScenario(scenario, seed.toLong())
+            runScenario(scenario, seed.toLong(), strictReader)
             pb.step()
         }
     }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
@@ -54,7 +54,10 @@ import java.util.stream.LongStream
  *
  * @param scenario The scenario to run
  */
-public fun runScenario(scenario: Scenario) {
+public fun runScenario(
+    scenario: Scenario,
+    strictReader: Boolean = false,
+) {
     val pb =
         ProgressBarBuilder().setInitialMax(scenario.runs.toLong()).setStyle(ProgressBarStyle.ASCII)
             .setTaskName("Simulating...").build()
@@ -62,7 +65,7 @@ public fun runScenario(scenario: Scenario) {
     val pool = ForkJoinPool(5)
     pool.submit {
         LongStream.range(0, scenario.runs.toLong()).parallel().forEach {
-            runScenario(scenario, scenario.initialSeed + it)
+            runScenario(scenario, scenario.initialSeed + it, strictReader)
             pb.step()
         }
         pb.close()
@@ -78,6 +81,7 @@ public fun runScenario(scenario: Scenario) {
 public fun runScenario(
     scenario: Scenario,
     seed: Long,
+    strictReader: Boolean = false,
 ): Unit =
     runSimulation {
         val serviceDomain = "compute.opendc.org"
@@ -92,7 +96,7 @@ public fun runScenario(
             val startTimeLong = workload.minOf { it.submittedAt }
             val startTime = Duration.ofMillis(startTimeLong)
 
-            val topology = clusterTopology(scenario.topologyPathSpec.pathToFile)
+            val topology = clusterTopology(scenario.topologyPathSpec.pathToFile, strictReader)
             val numHosts = topology.sumOf { it.hostSpecs.size }
             val gpuCount = topology.flatMap { it.hostSpecs }.maxOfOrNull { it.model.gpuModels.size } ?: 0
 


### PR DESCRIPTION
## Summary

Updated the JSON readers to ignore unknown keys and give a warning instead of throwing an error. 

Introduced the "-strict" flag to revert to the old behavior in which an error is thrown.

## Implementation Notes :hammer_and_pick:

The new system uses two readers: 
- One reader has the ignoreUnknownKeys set to true, which is used to read the files. 
- The second reader is strict and is used to warn the users which keys are ignored.

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*