### PR TITLE
Remove redundant --input-root CLI option

### DIFF
--- a/opendc-cli/README.md
+++ b/opendc-cli/README.md
@@ -1,0 +1,190 @@
+# opendc-cli
+
+Command-line interface for running OpenDC datacenter simulations. It builds into an `opendc`
+executable that runs, validates and inspects experiment files.
+
+## Installation
+
+Build a runnable distribution and put it on your `PATH`:
+
+```bash
+./gradlew :opendc-cli:installDist
+export PATH=$PATH:$(realpath opendc-cli/build/install/opendc/bin)
+```
+
+You can now call `opendc` from anywhere. Re-run `installDist` after code changes to refresh the
+binary.
+
+Alternatively, run without installing:
+
+```bash
+./gradlew :opendc-cli:run --args="run experiment.json"
+```
+
+Gradle captures the process output, so the live progress dashboard does not render as an interactive
+terminal this way. Prefer the installed binary for normal use.
+
+## Experiment file
+
+Every command takes an experiment JSON file. A minimal, self-contained one declares a topology, a
+workload, and how to schedule and export it. Save this as `experiment.json`:
+
+```json
+{
+    "name": "getting-started",
+    "topologies": [
+        {
+            "clusters": [
+                {
+                    "name": "C01",
+                    "hosts": [
+                        {
+                            "name": "H01",
+                            "count": 4,
+                            "cpu": { "coreCount": 16, "coreSpeed": "2.1 GHz" },
+                            "memory": { "size": "64 GiB" },
+                            "cpuPowerModel": {
+                                "type": "linear",
+                                "idlePower": "32 Watts",
+                                "maxPower": "180 Watts"
+                            }
+                        }
+                    ],
+                    "powerSource": { "name": "grid", "maxPower": "10000 Watts" }
+                }
+            ]
+        }
+    ],
+    "workloads": [
+        {
+            "type": "inline",
+            "tasks": [
+                {
+                    "id": 0,
+                    "name": "task-0",
+                    "submissionTime": "0 minutes",
+                    "duration": "10 minutes",
+                    "cpuCoreCount": 2,
+                    "cpuCapacity": "2.1 GHz",
+                    "memory": "2 GiB",
+                    "fragments": [
+                        { "duration": "10 minutes", "cpuUsage": "2.1 GHz" }
+                    ]
+                }
+            ]
+        }
+    ],
+    "allocationPolicies": [
+        { "type": "prefab", "scheduler": "Mem" }
+    ],
+    "exportModels": [
+        { "exportInterval": "1 minutes", "printFrequency": null }
+    ],
+    "runs": 1
+}
+```
+
+The inline workload keeps everything in one file. A larger study points `workloads` and
+`powerSource` at trace and carbon files instead, and adds more topologies or allocation policies to
+sweep; see `demo/sample.json` for such an experiment.
+
+### Splitting a file with `importFrom`
+
+Any object in the experiment (the experiment itself, a topology, a cluster, a host, a workload) can
+take the rest of its fields from another file with an `importFrom` key, so shared pieces live in one
+place and are reused:
+
+```json
+"topologies": [ { "importFrom": "topologies/surfsara.json" } ]
+```
+
+Keys written next to `importFrom` are kept and override the imported file, so you can adopt a file
+and then adjust it. Overrides replace a key whole; there is no deep merge:
+
+```json
+{ "importFrom": "hosts/big-host.json", "count": 64 }
+```
+
+Every relative `importFrom` path is resolved against the directory of the file that writes it, never
+against the directory you run `opendc` from. So `opendc run studies/big/experiment.json` reading
+`"importFrom": "topologies/surfsara.json"` looks for `studies/big/topologies/surfsara.json` whether
+you launch it from the repository root or from inside `studies/big`. Imports nest, and each file
+resolves its own paths against its own directory, so a path inside `topologies/surfsara.json` is
+relative to `studies/big/topologies/`, not to the experiment; absolute paths are taken as written.
+The practical consequence is that an experiment tree is relocatable only as a unit: move an
+experiment together with the files it imports and everything still resolves, but move or copy the
+experiment file alone and its relative imports break with a "does not exist" error naming where it
+looked. Keep imported files in a stable layout beneath the experiment and write each path relative to
+the file that references it, not to your shell. (Under `--legacy` the rule differs: legacy
+experiments resolve the topologies they reference against your current working directory, so run them
+from the directory those paths were written for.)
+
+## Commands
+
+```
+opendc run <experiment.json>        Simulate every scenario and write Parquet results.
+opendc validate <experiment.json>   Parse the file and report configuration issues.
+opendc show <experiment.json>       Print the datacenter topologies it declares.
+```
+
+Run any command with `--help` to see its options.
+
+### run
+
+`run` simulates each scenario in the experiment and writes per-run results, showing a live progress
+dashboard. Common options:
+
+```
+-o, --output <dir>        Directory for the Parquet results (default: output).
+-p, --parallelism <n>     Number of runs to simulate concurrently (default: 1).
+    --no-progress         Disable the live dashboard (use for CI or piped output).
+    --no-summary          Skip the in-memory metrics summary on very large sweeps.
+```
+
+```bash
+opendc run experiment.json -o results -p 4
+```
+
+### Option placement (a common trap)
+
+`--legacy` and `--strict` belong to the root `opendc` command, not to the subcommands. They must
+appear before the subcommand name. This fails:
+
+```bash
+opendc run experiment.json --legacy      # error: no such option: --legacy
+```
+
+Put the root flags first:
+
+```bash
+opendc --legacy run experiment.json
+```
+
+`--legacy` reads files written in the deprecated `opendc-experiments` JSON format; `--strict`
+rejects experiment files that contain unknown keys instead of ignoring them.
+
+## Debugging from IntelliJ
+
+The project imports as a Gradle project, so no extra setup is needed.
+
+1. Open `opendc-cli/src/main/kotlin/org/opendc/cli/Main.kt`.
+2. Click the green run arrow in the gutter next to `fun main`, then choose
+   `Modify Run Configuration...`.
+3. Set `Program arguments` to the command you want to debug, for example
+   `run opendc-cli/src/test/resources/experiments/tiny-experiment.json --no-progress`.
+4. Set `Working directory` to the repository root.
+5. Set breakpoints and start the configuration in Debug mode.
+
+Pass `--no-progress` while debugging so the terminal dashboard does not compete with the IDE console
+for the output stream.
+
+## Advanced example
+
+```bash
+opendc --legacy run experiments/failure_experiment.json -o results -p 4 --no-progress
+```
+
+This reads `failure_experiment.json` as a deprecated `opendc-experiments` document (`--legacy`, placed
+before `run` because it is a root flag), simulates its scenarios four at a time (`-p 4`), and writes
+the Parquet results under `results/` (`-o results`). `--no-progress` turns off the interactive
+dashboard so the plain log output is safe to capture in a file or CI pipeline.

--- a/opendc-cli/src/main/kotlin/org/opendc/cli/Main.kt
+++ b/opendc-cli/src/main/kotlin/org/opendc/cli/Main.kt
@@ -106,15 +106,9 @@ internal abstract class ExperimentCommand(
         get() = currentContext.findObject<ExperimentReadOptions>()?.strict == true
 
     /**
-     * The directory the experiment's relative paths resolve against, absent an explicit `--input-root`.
-     *
-     * A legacy experiment names its topologies and traces relative to the directory it is *run from*,
-     * because that is what the deprecated runner resolved against; an SDK experiment names its traces
-     * relative to the file itself. The topologies inlined by [loadExperiment] and the traces the runner
-     * provisions later must share this one root, or the two halves of the same experiment would be
-     * looked up in different places.
+     * The directory the experiment should be resolved at
      */
-    protected val defaultInputRoot: Path
+    protected val experimentBaseDirectory: Path
         get() =
             if (isLegacy) {
                 Path.of("").toAbsolutePath()
@@ -129,14 +123,17 @@ internal abstract class ExperimentCommand(
      * [root]; otherwise it is SDK-model JSON, which composes the files it names with `importFrom`
      * relative to itself and so needs no root.
      */
-    protected fun loadExperiment(root: Path = defaultInputRoot): ExperimentSpec =
+    protected fun loadExperiment(): ExperimentSpec =
         try {
             if (isLegacy) {
-                readLegacyExperiment(experimentFile, root.toFile(), isStrict)
+                readLegacyExperiment(experimentFile, experimentBaseDirectory.toFile(), isStrict)
             } else {
                 readExperiment(experimentFile, isStrict)
             }
         } catch (e: Exception) {
-            throw CliktError("Could not read experiment '${experimentFile.path}': ${e.message}")
+            throw CliktError(
+                "Could not read experiment '${experimentFile.path}': ${e.message}",
+                cause = e
+            )
         }
 }

--- a/opendc-cli/src/main/kotlin/org/opendc/cli/Main.kt
+++ b/opendc-cli/src/main/kotlin/org/opendc/cli/Main.kt
@@ -133,7 +133,7 @@ internal abstract class ExperimentCommand(
         } catch (e: Exception) {
             throw CliktError(
                 "Could not read experiment '${experimentFile.path}': ${e.message}",
-                cause = e
+                cause = e,
             )
         }
 }

--- a/opendc-cli/src/main/kotlin/org/opendc/cli/RunCommand.kt
+++ b/opendc-cli/src/main/kotlin/org/opendc/cli/RunCommand.kt
@@ -47,16 +47,13 @@ internal class RunCommand(config: CliConfig = CliConfig.DEFAULTS) : ExperimentCo
     override fun help(context: Context): String =
         "Run an experiment: simulate every scenario and write the results to Parquet, showing a live progress dashboard."
 
-    private val output by option("--output", "-o", help = "Directory for the Parquet results.")
+    private val output by option(
+        "--output",
+        "-o",
+        help = "Directory for the Parquet results."
+    )
         .path(canBeFile = false)
         .default(Path.of("output"))
-
-    private val inputRoot by option(
-        "--input-root",
-        help =
-            "Root for resolving named/relative topology, workload and trace references " +
-                "(default: the experiment file's directory, or the working directory under --legacy).",
-    ).path(canBeFile = false, mustExist = true)
 
     private val parallelism by option(
         "--parallelism",
@@ -66,7 +63,15 @@ internal class RunCommand(config: CliConfig = CliConfig.DEFAULTS) : ExperimentCo
         .int()
         .default(1)
 
-    private val noProgress by option("--no-progress", help = "Disable the live progress dashboard.").flag()
+    private val noProgress by option(
+        "--no-progress",
+        help = "Disable the live progress dashboard."
+    ).flag()
+
+    private val experimentPath by option(
+        "--experiment-path",
+        help = "Legacy support for the experiment path. Does nothing."
+    ).flag()
 
     private val noSummary by option(
         "--no-summary",
@@ -79,10 +84,8 @@ internal class RunCommand(config: CliConfig = CliConfig.DEFAULTS) : ExperimentCo
     )
 
     override fun run() {
-        // The topologies inlined while loading and the traces provisioned while running are resolved
-        // against the same root, so `--input-root` moves the whole experiment rather than half of it.
-        val root = inputRoot ?: defaultInputRoot
-        val experiment = loadExperiment(root)
+        val experiment = loadExperiment()
+
         if (!renderValidation(terminal, experimentFile.name, experiment.validate(), config, showSuccess = false)) {
             throw ProgramResult(1)
         }
@@ -90,7 +93,7 @@ internal class RunCommand(config: CliConfig = CliConfig.DEFAULTS) : ExperimentCo
         val request =
             RunRequest(
                 experiment = experiment,
-                inputRoot = root,
+                inputRoot = experimentBaseDirectory,
                 output = output,
                 parallelism = parallelism,
                 wantSummary = !noSummary,

--- a/opendc-cli/src/main/kotlin/org/opendc/cli/RunCommand.kt
+++ b/opendc-cli/src/main/kotlin/org/opendc/cli/RunCommand.kt
@@ -50,7 +50,7 @@ internal class RunCommand(config: CliConfig = CliConfig.DEFAULTS) : ExperimentCo
     private val output by option(
         "--output",
         "-o",
-        help = "Directory for the Parquet results."
+        help = "Directory for the Parquet results.",
     )
         .path(canBeFile = false)
         .default(Path.of("output"))
@@ -65,12 +65,12 @@ internal class RunCommand(config: CliConfig = CliConfig.DEFAULTS) : ExperimentCo
 
     private val noProgress by option(
         "--no-progress",
-        help = "Disable the live progress dashboard."
+        help = "Disable the live progress dashboard.",
     ).flag()
 
     private val experimentPath by option(
         "--experiment-path",
-        help = "Legacy support for the experiment path. Does nothing."
+        help = "Legacy support for the experiment path. Does nothing.",
     ).flag()
 
     private val noSummary by option(


### PR DESCRIPTION
## Summary

The `--input-root` CLI option was designed before the `ExperimentImports.kt` system was designed. Its goal was to tell the experiment parser where to grab workload traces from on the filesystem.

This functionality is not necessarily needed. Now, experiments are always resolved to the parent directory they are part of. Relative paths are then parsed from the experiment file root.

Example: assume the following directory structure

```
demo
├── carbon_traces
│   └── NL_2021-2024.parquet
├── sample.json
└── workload_traces
    └── surf_week
        ├── fragments.parquet
        └── tasks.parquet
```

Running `opnedc run demo/sample.json` will resolve `demo` to be the working directory of the experiment. Therefore, `NL_2021-2024.parquet` can be referenced as a named reference in the experiment directly under `carbon_traces/NL_2021-2024.parquet`.

It is still possible to import traces from arbitrary locations (specifically what `--input-root` was made for): simply use the `uri` reference type instead of `named` and specify the absolute path: `file:///home/user/traces/workload_traces/surf_week`.

## Breaking API Changes

No more `--input-root`. Legacy experiments (`--legacy` option) will always resolve to the current working directory for compatibility reasons. 

## Nice to have

Also added documentation in opendc-cli module to explain how to use the new CLI. This should eventually make its way into the publics docs.