### PR TITLE
Changed workload to a queue

### DIFF
--- a/opendc-cli/src/main/kotlin/org/opendc/cli/progress/ProgressSink.kt
+++ b/opendc-cli/src/main/kotlin/org/opendc/cli/progress/ProgressSink.kt
@@ -23,7 +23,7 @@
 package org.opendc.cli.progress
 
 import org.opendc.sdk.model.telemetry.OutputFileSpec
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 import org.opendc.sdk.runner.telemetry.sink.OutputSink
 import org.opendc.sdk.runner.telemetry.sink.RunContext
 import org.opendc.sdk.runner.telemetry.sink.SinkResult
@@ -38,9 +38,9 @@ internal class ProgressSink(private val progress: ExperimentProgress) : OutputSi
     override fun open(context: RunContext): SinkSession {
         val key = RunKey(context.scenarioId, context.seed)
         return object : SinkSession {
-            override val monitor: ComputeMonitor =
-                object : ComputeMonitor {
-                    override fun record(reader: ServiceSample) {
+            override val monitor: MetricExporter =
+                object : MetricExporter {
+                    override fun export(reader: ServiceSample) {
                         progress.update(key, (reader.tasksCompleted + reader.tasksTerminated).toLong())
                     }
                 }

--- a/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
+++ b/opendc-experiments/opendc-experiments-base/src/main/kotlin/org/opendc/experiments/base/runner/ScenarioRunner.kt
@@ -39,7 +39,7 @@ import org.opendc.sdk.runner.provision.registerComputeMonitor
 import org.opendc.sdk.runner.provision.setupComputeService
 import org.opendc.sdk.runner.provision.setupHosts
 import org.opendc.sdk.runner.telemetry.parquet.ComputeExportConfig
-import org.opendc.sdk.runner.telemetry.parquet.ParquetComputeMonitor
+import org.opendc.sdk.runner.telemetry.parquet.ParquetMetricExporter
 import org.opendc.sdk.runner.telemetry.parquet.withGpuColumns
 import org.opendc.simulator.compute.power.CarbonModel
 import org.opendc.simulator.compute.power.CarbonReceiver
@@ -193,7 +193,7 @@ public fun initializeExportModel(
     provisioner.runStep(
         registerComputeMonitor(
             serviceDomain,
-            ParquetComputeMonitor(
+            ParquetMetricExporter(
                 File("${scenario.outputFolder}/raw-output/$index"),
                 "seed=$seed",
                 bufferSize = 4096,

--- a/opendc-sdk/opendc-sdk-runner/README.md
+++ b/opendc-sdk/opendc-sdk-runner/README.md
@@ -41,7 +41,7 @@ trace on a power source.
 ## Modelling output: the sink pattern
 
 Output is modelled as composable **sinks**. A sink is a factory that opens a per-run session yielding
-a `ComputeMonitor`; the runner fans every metric record out to all sinks, so they compose freely —
+a `MetricExporter`; the runner fans every metric record out to all sinks, so they compose freely —
 parquet, in-memory capture, and streaming can all observe the same run.
 
 | Sink | Purpose |
@@ -49,7 +49,7 @@ parquet, in-memory capture, and streaming can all observe the same run.
 | `ParquetSink` | Writes the canonical layout `<root>/<experiment>/raw-output/<id>/seed=<seed>/{host,task,powerSource,battery,service}.parquet`. Added by `builder().output(root)`. |
 | `InMemorySink` | Captures selected tables as strongly-typed `HostSample`/`TaskSample`/`HostSample`/`PowerSourceSample`/`HostSample`, available on `RunResult.metrics`. |
 | `CallbackSink` | Streams each snapshot to per-table callbacks without retaining it — for progress or large sweeps. |
-| `MonitorSink` | Feeds a caller-supplied `ComputeMonitor` — the full-control escape hatch. |
+| `MonitorSink` | Feeds a caller-supplied `MetricExporter` — the full-control escape hatch. |
 
 `RunResult` exposes convenience accessors: `outputPath` (the parquet directory) and `metrics` (the
 in-memory `CollectedMetrics`), alongside the raw `results: List<SinkResult>`.

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/CompositeMetricExporter.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/CompositeMetricExporter.kt
@@ -22,7 +22,7 @@
 
 package org.opendc.sdk.runner.executor
 
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 import org.opendc.sdk.runner.telemetry.table.battery.BatterySample
 import org.opendc.sdk.runner.telemetry.table.host.HostSample
 import org.opendc.sdk.runner.telemetry.table.powerSource.PowerSourceSample
@@ -33,16 +33,16 @@ import org.opendc.sdk.runner.telemetry.table.task.TaskSample
  * Fans every metric record out to all [monitors] and closes any that are [AutoCloseable] when the
  * run ends. This is how parquet, in-memory and callback sinks observe a single run together.
  */
-internal class CompositeComputeMonitor(private val monitors: List<ComputeMonitor>) : ComputeMonitor, AutoCloseable {
-    override fun record(reader: BatterySample): Unit = monitors.forEach { it.record(reader) }
+internal class CompositeMetricExporter(private val monitors: List<MetricExporter>) : MetricExporter, AutoCloseable {
+    override fun export(reader: BatterySample): Unit = monitors.forEach { it.export(reader) }
 
-    override fun record(reader: HostSample): Unit = monitors.forEach { it.record(reader) }
+    override fun export(reader: HostSample): Unit = monitors.forEach { it.export(reader) }
 
-    override fun record(reader: PowerSourceSample): Unit = monitors.forEach { it.record(reader) }
+    override fun export(reader: PowerSourceSample): Unit = monitors.forEach { it.export(reader) }
 
-    override fun record(reader: ServiceSample): Unit = monitors.forEach { it.record(reader) }
+    override fun export(reader: ServiceSample): Unit = monitors.forEach { it.export(reader) }
 
-    override fun record(reader: TaskSample): Unit = monitors.forEach { it.record(reader) }
+    override fun export(reader: TaskSample): Unit = monitors.forEach { it.export(reader) }
 
     override fun close(): Unit = monitors.forEach { if (it is AutoCloseable) it.close() }
 }

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioExecutor.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioExecutor.kt
@@ -95,6 +95,9 @@ private class ScenarioRun(
     suspend fun execute(): RunResult {
         val workload = scenario.workload.toServiceTasks(scenario.checkpointModel, resources::resolve)
 
+        println("Workload Loaded")
+        Thread.sleep(10_000)
+
         val startTime = workload.minOf { it.submittedAt }
         val clusters = scenario.topology.toClusterSpecs(resources::resolve)
 

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioExecutor.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioExecutor.kt
@@ -95,9 +95,6 @@ private class ScenarioRun(
     suspend fun execute(): RunResult {
         val workload = scenario.workload.toServiceTasks(scenario.checkpointModel, resources::resolve)
 
-        println("Workload Loaded")
-        Thread.sleep(10_000)
-
         val startTime = workload.minOf { it.submittedAt }
         val clusters = scenario.topology.toClusterSpecs(resources::resolve)
 

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioReplayer.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioReplayer.kt
@@ -35,9 +35,11 @@ import org.opendc.sdk.model.resource.ResourceReference
 import org.opendc.sdk.runner.factory.toEngine
 import java.nio.file.Path
 import java.time.InstantSource
+import java.util.Queue
 import java.util.Random
 import kotlin.coroutines.coroutineContext
 import kotlin.math.max
+import kotlin.time.Duration.Companion.milliseconds
 import org.opendc.sdk.model.failure.FailureModelSpec as SdkFailureModel
 
 /**
@@ -45,12 +47,15 @@ import org.opendc.sdk.model.failure.FailureModelSpec as SdkFailureModel
  * submission time, and injecting the failures described by [failureModel]. Blocks (in virtual time)
  * until every task reaches [TaskState.DELETED].
  *
+ * [trace] must already be ordered by submission time; tasks are [Queue.poll]ed off one at a time and
+ * dropped as they are submitted, so a large trace does not stay fully resident for the whole run.
+ *
  * A decoupled fork of the experiments-base replayer that sources failures from the SDK model
  * instead of experiment specs.
  */
 internal suspend fun ComputeService.replay(
     clock: InstantSource,
-    trace: List<ServiceTask>,
+    trace: Queue<ServiceTask>,
     failureModel: SdkFailureModel,
     seed: Long,
     resolve: (ResourceReference) -> Path,
@@ -62,12 +67,12 @@ internal suspend fun ComputeService.replay(
         coroutineScope {
             engineFailure?.start()
             var simulationOffset = Long.MIN_VALUE
-            for (task in trace.sortedBy { it.submittedAt }) {
+            for (task in generateSequence(trace::poll)) {
                 val now = clock.millis()
                 val start = task.submittedAt
                 if (simulationOffset == Long.MIN_VALUE) simulationOffset = start - now
                 if (!submitImmediately) {
-                    delay(max(0, start - now - simulationOffset))
+                    delay(max(0, start - now - simulationOffset).milliseconds)
                     task.deadline -= simulationOffset
                 }
                 launch {

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/factory/WorkloadFactory.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/factory/WorkloadFactory.kt
@@ -36,35 +36,46 @@ import org.opendc.simulator.compute.workload.trace.TraceFragment
 import org.opendc.simulator.compute.workload.trace.scaling.NoDelayScaling
 import org.opendc.simulator.compute.workload.trace.scaling.PerfectScaling
 import java.nio.file.Path
+import java.util.ArrayDeque
+import java.util.Queue
 import org.opendc.simulator.compute.workload.trace.TraceWorkload as EngineTraceWorkload
 import org.opendc.simulator.compute.workload.trace.scaling.ScalingPolicy as EngineScalingPolicy
 
 /**
- * Materializes an SDK [WorkloadSpec] into the engine's list of [ServiceTask]s. Trace workloads are
- * loaded from the resource resolved by [resolve]; inline workloads are built in memory.
+ * Materializes an SDK [WorkloadSpec] into a submission-order queue of [ServiceTask]s. Trace workloads
+ * are loaded from the resource resolved by [resolve]; inline workloads are built in memory. Tasks are
+ * meant to be [Queue.poll]ed off as they are submitted, so the replayer never holds onto tasks it has
+ * already handed off.
  */
 internal fun WorkloadSpec.toServiceTasks(
     checkpoint: CheckpointSpec?,
     resolve: (ResourceReference) -> Path,
-): List<ServiceTask> =
+): Queue<ServiceTask> =
     when (this) {
         is TraceWorkloadSpec -> loadTrace(resolve(source), checkpoint)
-        is InlineWorkloadSpec -> tasks.map { it.toServiceTask(scalingPolicy.toEngine(), checkpoint) }
+        is InlineWorkloadSpec ->
+            ArrayDeque(
+                tasks
+                    .sortedBy { it.submissionTime.toMsLong() }
+                    .map { it.toServiceTask(scalingPolicy.toEngine(), checkpoint) },
+            )
     }
 
 private fun TraceWorkloadSpec.loadTrace(
     path: Path,
     checkpoint: CheckpointSpec?,
-): List<ServiceTask> =
-    ComputeWorkloadLoader(
-        path.toFile(),
-        submissionTime,
-        checkpoint.intervalMs(),
-        checkpoint.durationMs(),
-        checkpoint.scaling(),
-        scalingPolicy.toEngine(),
-        deferAll,
-    ).sampleByLoad(sampleFraction)
+): Queue<ServiceTask> =
+    ArrayDeque(
+        ComputeWorkloadLoader(
+            path.toFile(),
+            submissionTime,
+            checkpoint.intervalMs(),
+            checkpoint.durationMs(),
+            checkpoint.scaling(),
+            scalingPolicy.toEngine(),
+            deferAll,
+        ).sampleByLoad(sampleFraction),
+    )
 
 private fun TaskSpec.toServiceTask(
     scaling: EngineScalingPolicy,

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/provision/ComputeMonitorProvisioningStep.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/provision/ComputeMonitorProvisioningStep.kt
@@ -25,16 +25,16 @@ package org.opendc.sdk.runner.provision
 import org.opendc.compute.simulator.service.ComputeService
 import org.opendc.sdk.model.telemetry.OutputFileSpec
 import org.opendc.sdk.runner.telemetry.ComputeMetricReader
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 import java.time.Duration
 
 /**
  * A [ProvisioningStep] that provisions a [ComputeMetricReader] to periodically collect the metrics of a [ComputeService]
- * and report them to a [ComputeMonitor].
+ * and report them to a [MetricExporter].
  */
 public class ComputeMonitorProvisioningStep(
     private val serviceDomain: String,
-    private val monitor: ComputeMonitor,
+    private val monitor: MetricExporter,
     private val exportInterval: Duration,
     private val startTime: Duration = Duration.ofMillis(0),
     private val filesToExport: Map<OutputFileSpec, Boolean> =

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/provision/ComputeSteps.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/provision/ComputeSteps.kt
@@ -28,7 +28,7 @@ import org.opendc.compute.simulator.scheduler.ComputeScheduler
 import org.opendc.compute.topology.specs.ClusterSpec
 import org.opendc.compute.topology.specs.HostSpec
 import org.opendc.sdk.model.telemetry.OutputFileSpec
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 import java.time.Duration
 
 /**
@@ -49,15 +49,15 @@ public fun setupComputeService(
 
 /**
  * Return a [ProvisioningStep] that installs a [ComputeMetricReader] to periodically collect the metrics of a
- * [ComputeService] and report them to a [ComputeMonitor].
+ * [ComputeService] and report them to a [MetricExporter].
  *
  * @param serviceDomain The service domain at which the [ComputeService] is located.
- * @param monitor The [ComputeMonitor] to install.
+ * @param monitor The [MetricExporter] to install.
  * @param exportInterval The interval between which to collect the metrics.
  */
 public fun registerComputeMonitor(
     serviceDomain: String,
-    monitor: ComputeMonitor,
+    monitor: MetricExporter,
     exportInterval: Duration = Duration.ofMinutes(5),
     startTime: Duration = Duration.ofMillis(0),
     filesToExport: Map<OutputFileSpec, Boolean> =

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/ComputeMetricReader.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/ComputeMetricReader.kt
@@ -53,7 +53,7 @@ import kotlin.time.Duration.Companion.milliseconds
 public class ComputeMetricReader(
     dispatcher: Dispatcher,
     private val service: ComputeService,
-    private val monitor: ComputeMonitor,
+    private val monitor: MetricExporter,
     private val exportInterval: Duration = Duration.ofMinutes(5),
     private val startTime: Duration = Duration.ofMillis(0),
     private val toMonitor: Map<OutputFileSpec, Boolean> =
@@ -129,40 +129,35 @@ public class ComputeMetricReader(
             if (toMonitor[OutputFileSpec.BATTERY] == true) {
                 for (battery in this.service.batteries) {
                     val batterySample = this.batterySampler.sample(now, battery)
-                    this.monitor.record(batterySample)
+                    this.monitor.export(batterySample)
                 }
             }
 
             if (toMonitor[OutputFileSpec.HOST] == true) {
                 for (host in this.service.hosts) {
                     val hostSample = this.hostSampler.sample(now, host)
-                    this.monitor.record(hostSample)
+                    this.monitor.export(hostSample)
                 }
             }
 
             if (toMonitor[OutputFileSpec.POWER_SOURCE] == true) {
                 for (powerSource in this.service.powerSources) {
                     val powerSourceSample = this.powerSourceSampler.sample(now, powerSource)
-                    this.monitor.record(powerSourceSample)
+                    this.monitor.export(powerSourceSample)
                 }
             }
 
             if (toMonitor[OutputFileSpec.SERVICE] == true) {
                 val serviceSample = this.serviceSampler.sample(now)
-                this.monitor.record(serviceSample)
+                this.monitor.export(serviceSample)
             }
 
             if (toMonitor[OutputFileSpec.TASK] == true) {
                 for (task in this.service.tasks.values) {
                     val taskSample = this.taskSampler.sample(now, task)
-                    this.monitor.record(taskSample)
+                    this.monitor.export(taskSample)
                 }
             }
-
-//            for (task in this.service.tasksToRemove) {
-//                task.delete()
-//            }
-//            this.service.clearTasksToRemove()
 
             if (printFrequency != null && loggCounter % printFrequency == 0) {
                 // TODO: Fix this!
@@ -192,6 +187,6 @@ public class ComputeMetricReader(
         val now = this.clock.instant()
 
         val taskSample = this.taskSampler.sample(now, task)
-        this.monitor.record(taskSample)
+        this.monitor.export(taskSample)
     }
 }

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/MetricExporter.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/MetricExporter.kt
@@ -29,31 +29,31 @@ import org.opendc.sdk.runner.telemetry.table.service.ServiceSample
 import org.opendc.sdk.runner.telemetry.table.task.TaskSample
 
 /**
- * A monitor that tracks the metrics and events of the OpenDC Compute service.
+ * A monitor that exports Samples.
  */
-public interface ComputeMonitor {
+public interface MetricExporter {
     /**
      * Record an entry with the specified [reader].
      */
-    public fun record(reader: BatterySample) {}
+    public fun export(reader: BatterySample) {}
 
     /**
      * Record an entry with the specified [reader].
      */
-    public fun record(reader: HostSample) {}
+    public fun export(reader: HostSample) {}
 
     /**
      * Record an entry with the specified [reader].
      */
-    public fun record(reader: PowerSourceSample) {}
+    public fun export(reader: PowerSourceSample) {}
 
     /**
      * Record an entry with the specified [reader].
      */
-    public fun record(reader: ServiceSample) {}
+    public fun export(reader: ServiceSample) {}
 
     /**
      * Record an entry with the specified [reader].
      */
-    public fun record(reader: TaskSample) {}
+    public fun export(reader: TaskSample) {}
 }

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/parquet/ParquetMetricExporter.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/parquet/ParquetMetricExporter.kt
@@ -23,7 +23,7 @@
 package org.opendc.sdk.runner.telemetry.parquet
 
 import org.opendc.sdk.model.telemetry.OutputFileSpec
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 import org.opendc.sdk.runner.telemetry.table.battery.BatterySample
 import org.opendc.sdk.runner.telemetry.table.host.HostSample
 import org.opendc.sdk.runner.telemetry.table.powerSource.PowerSourceSample
@@ -35,32 +35,32 @@ import org.opendc.trace.util.parquet.exporter.Exporter
 import java.io.File
 
 /**
- * A [ComputeMonitor] that logs the events to a Parquet file.
+ * A [MetricExporter] that logs the events to a Parquet file.
  */
-public class ParquetComputeMonitor(
+public class ParquetMetricExporter(
     private val batteryExporter: Exporter<BatterySample>?,
     private val hostExporter: Exporter<HostSample>?,
     private val powerSourceExporter: Exporter<PowerSourceSample>?,
     private val serviceExporter: Exporter<ServiceSample>?,
     private val taskExporter: Exporter<TaskSample>?,
-) : ComputeMonitor, AutoCloseable {
-    override fun record(reader: BatterySample) {
+) : MetricExporter, AutoCloseable {
+    override fun export(reader: BatterySample) {
         batteryExporter?.write(reader)
     }
 
-    override fun record(reader: HostSample) {
+    override fun export(reader: HostSample) {
         hostExporter?.write(reader)
     }
 
-    override fun record(reader: PowerSourceSample) {
+    override fun export(reader: PowerSourceSample) {
         powerSourceExporter?.write(reader)
     }
 
-    override fun record(reader: ServiceSample) {
+    override fun export(reader: ServiceSample) {
         serviceExporter?.write(reader)
     }
 
-    override fun record(reader: TaskSample) {
+    override fun export(reader: TaskSample) {
         taskExporter?.write(reader)
     }
 
@@ -86,7 +86,7 @@ public class ParquetComputeMonitor(
             bufferSize: Int,
             filesToExport: Map<OutputFileSpec, Boolean>,
             computeExportConfig: ComputeExportConfig,
-        ): ParquetComputeMonitor =
+        ): ParquetMetricExporter =
             invoke(
                 base = base,
                 partition = partition,
@@ -118,7 +118,7 @@ public class ParquetComputeMonitor(
             powerSourceExportColumns: Collection<ExportColumn<PowerSourceSample>>? = null,
             serviceExportColumns: Collection<ExportColumn<ServiceSample>>? = null,
             taskExportColumns: Collection<ExportColumn<TaskSample>>? = null,
-        ): ParquetComputeMonitor {
+        ): ParquetMetricExporter {
             // Loads the fields in case they need to be retrieved if optional params are omitted.
             ComputeExportConfig.loadDfltColumns()
 
@@ -177,7 +177,7 @@ public class ParquetComputeMonitor(
                     null
                 }
 
-            return ParquetComputeMonitor(
+            return ParquetMetricExporter(
                 batteryExporter = batteryExporter,
                 hostExporter = hostExporter,
                 powerSourceExporter = powerSourceExporter,

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/CallbackSink.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/CallbackSink.kt
@@ -23,7 +23,7 @@
 package org.opendc.sdk.runner.telemetry.sink
 
 import org.opendc.sdk.model.telemetry.OutputFileSpec
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 import org.opendc.sdk.runner.telemetry.table.battery.BatterySample
 import org.opendc.sdk.runner.telemetry.table.host.HostSample
 import org.opendc.sdk.runner.telemetry.table.powerSource.PowerSourceSample
@@ -46,25 +46,25 @@ public class CallbackSink(
 ) : OutputSink {
     override fun open(context: RunContext): SinkSession =
         object : SinkSession {
-            override val monitor: ComputeMonitor =
-                object : ComputeMonitor {
-                    override fun record(reader: BatterySample) {
+            override val monitor: MetricExporter =
+                object : MetricExporter {
+                    override fun export(reader: BatterySample) {
                         onBattery?.invoke(reader)
                     }
 
-                    override fun record(reader: HostSample) {
+                    override fun export(reader: HostSample) {
                         onHost?.invoke(reader)
                     }
 
-                    override fun record(reader: PowerSourceSample) {
+                    override fun export(reader: PowerSourceSample) {
                         onPowerSource?.invoke(reader)
                     }
 
-                    override fun record(reader: ServiceSample) {
+                    override fun export(reader: ServiceSample) {
                         onService?.invoke(reader)
                     }
 
-                    override fun record(reader: TaskSample) {
+                    override fun export(reader: TaskSample) {
                         onTask?.invoke(reader)
                     }
                 }

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/InMemorySink.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/InMemorySink.kt
@@ -23,7 +23,7 @@
 package org.opendc.sdk.runner.telemetry.sink
 
 import org.opendc.sdk.model.telemetry.OutputFileSpec
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 import org.opendc.sdk.runner.telemetry.table.battery.BatterySample
 import org.opendc.sdk.runner.telemetry.table.host.HostSample
 import org.opendc.sdk.runner.telemetry.table.powerSource.PowerSourceSample
@@ -50,25 +50,25 @@ public class InMemorySink
             private val powerSource = mutableListOf<PowerSourceSample>()
             private val battery = mutableListOf<BatterySample>()
 
-            override val monitor: ComputeMonitor =
-                object : ComputeMonitor {
-                    override fun record(reader: BatterySample) {
+            override val monitor: MetricExporter =
+                object : MetricExporter {
+                    override fun export(reader: BatterySample) {
                         if (OutputFileSpec.BATTERY in captureTables) battery += reader
                     }
 
-                    override fun record(reader: HostSample) {
+                    override fun export(reader: HostSample) {
                         if (OutputFileSpec.HOST in captureTables) host += reader
                     }
 
-                    override fun record(reader: PowerSourceSample) {
+                    override fun export(reader: PowerSourceSample) {
                         if (OutputFileSpec.POWER_SOURCE in captureTables) powerSource += reader
                     }
 
-                    override fun record(reader: ServiceSample) {
+                    override fun export(reader: ServiceSample) {
                         if (OutputFileSpec.SERVICE in captureTables) service += reader
                     }
 
-                    override fun record(reader: TaskSample) {
+                    override fun export(reader: TaskSample) {
                         if (OutputFileSpec.TASK in captureTables) task += reader
                     }
                 }

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/MonitorSink.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/MonitorSink.kt
@@ -23,10 +23,10 @@
 package org.opendc.sdk.runner.telemetry.sink
 
 import org.opendc.sdk.model.telemetry.OutputFileSpec
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 
 /**
- * Feeds each run's metrics to a caller-supplied [ComputeMonitor] — the full-control escape hatch
+ * Feeds each run's metrics to a caller-supplied [MetricExporter] — the full-control escape hatch
  * for consumers with an existing monitor (e.g. the web module's reporting monitor).
  *
  * A fresh monitor is produced per run by [factory]; the fixed-instance secondary constructor is
@@ -39,17 +39,17 @@ public class MonitorSink
     @JvmOverloads
     constructor(
         private val tables: Set<OutputFileSpec> = OutputFileSpec.entries.toSet(),
-        private val factory: (RunContext) -> ComputeMonitor,
+        private val factory: (RunContext) -> MetricExporter,
     ) : OutputSink {
         public constructor(
-            monitor: ComputeMonitor,
+            monitor: MetricExporter,
             tables: Set<OutputFileSpec> = OutputFileSpec.entries.toSet(),
         ) : this(tables, { monitor })
 
         override fun open(context: RunContext): SinkSession {
             val runMonitor = factory(context)
             return object : SinkSession {
-                override val monitor: ComputeMonitor = runMonitor
+                override val monitor: MetricExporter = runMonitor
                 override val tables: Set<OutputFileSpec> = this@MonitorSink.tables
 
                 override fun result(): SinkResult? = null

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/OutputSink.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/OutputSink.kt
@@ -24,7 +24,7 @@ package org.opendc.sdk.runner.telemetry.sink
 
 import org.opendc.sdk.model.telemetry.ExportSpec
 import org.opendc.sdk.model.telemetry.OutputFileSpec
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 
 /**
  * A destination for the metrics produced by a simulation run.
@@ -42,12 +42,12 @@ public fun interface OutputSink {
 /**
  * The per-run state of an [OutputSink].
  *
- * @property monitor The [ComputeMonitor] fed the run's metric records.
+ * @property monitor The [MetricExporter] fed the run's metric records.
  * @property tables The metric tables this session needs recorded; the runner records the union
  *   across all sessions.
  */
 public interface SinkSession {
-    public val monitor: ComputeMonitor
+    public val monitor: MetricExporter
     public val tables: Set<OutputFileSpec>
     public val exportSpec: ExportSpec?
         get() = null

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/ParquetSink.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/sink/ParquetSink.kt
@@ -23,8 +23,8 @@
 package org.opendc.sdk.runner.telemetry.sink
 
 import org.opendc.sdk.model.telemetry.OutputFileSpec
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
-import org.opendc.sdk.runner.telemetry.parquet.ParquetComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
+import org.opendc.sdk.runner.telemetry.parquet.ParquetMetricExporter
 import java.nio.file.Path
 
 /**
@@ -47,7 +47,7 @@ public class ParquetSink
             val base = root.resolve(context.experimentName).resolve("raw-output").resolve(context.scenarioId.toString())
             val partition = "seed=${context.seed}"
             val parquetMonitor =
-                ParquetComputeMonitor(
+                ParquetMetricExporter(
                     base.toFile(),
                     partition,
                     bufferSize,
@@ -55,7 +55,7 @@ public class ParquetSink
                     export.config,
                 )
             return object : SinkSession {
-                override val monitor: ComputeMonitor = parquetMonitor
+                override val monitor: MetricExporter = parquetMonitor
                 override val tables: Set<OutputFileSpec> = export.filesToExport.filterValues { it }.keys
 
                 override fun result(): SinkResult = ParquetOutput(base.resolve(partition))

--- a/opendc-sdk/opendc-sdk-runner/src/test/kotlin/org/opendc/sdk/runner/base/harness/TestMetricExporter.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/test/kotlin/org/opendc/sdk/runner/base/harness/TestMetricExporter.kt
@@ -24,24 +24,24 @@ package org.opendc.sdk.runner.base.harness
 
 import org.opendc.compute.simulator.service.ServiceTask
 import org.opendc.compute.simulator.telemetry.TaskListener
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 import org.opendc.sdk.runner.telemetry.table.host.HostSample
 import org.opendc.sdk.runner.telemetry.table.powerSource.PowerSourceSample
 import org.opendc.sdk.runner.telemetry.table.service.ServiceSample
 import org.opendc.sdk.runner.telemetry.table.task.TaskSample
 
 /**
- * A [ComputeMonitor] that captures per-record telemetry into in-memory series, ported verbatim from
+ * A [MetricExporter] that captures per-record telemetry into in-memory series, ported verbatim from
  * the legacy `opendc-experiments-base` test suite so the ported assertions read against identical
  * fields and values.
  */
-class TestComputeMonitor : ComputeMonitor, TaskListener {
+class TestMetricExporter : MetricExporter, TaskListener {
     var taskCpuDemands = mutableMapOf<Int, ArrayList<Double>>()
     var taskCpuSupplied = mutableMapOf<Int, ArrayList<Double>>()
     var taskGpuDemands = mutableMapOf<Int, ArrayList<Double?>?>()
     var taskGpuSupplied = mutableMapOf<Int, ArrayList<Double?>?>()
 
-    override fun record(reader: TaskSample) {
+    override fun export(reader: TaskSample) {
         val taskName: Int = reader.taskId
 
         if (taskName in taskCpuDemands) {
@@ -73,7 +73,7 @@ class TestComputeMonitor : ComputeMonitor, TaskListener {
 
     var maxTimestamp = 0L
 
-    override fun record(reader: ServiceSample) {
+    override fun export(reader: ServiceSample) {
         attemptsSuccess = reader.attemptsSuccess
         attemptsFailure = reader.attemptsFailure
         attemptsError = 0
@@ -104,7 +104,7 @@ class TestComputeMonitor : ComputeMonitor, TaskListener {
     var hostPowerDraws = mutableMapOf<String, ArrayList<Double>>()
     var hostEnergyUsages = mutableMapOf<String, ArrayList<Double>>()
 
-    override fun record(reader: HostSample) {
+    override fun export(reader: HostSample) {
         val hostName: String = reader.hostName ?: "unknown-host"
 
         if (hostName !in hostCpuDemands) {
@@ -151,7 +151,7 @@ class TestComputeMonitor : ComputeMonitor, TaskListener {
     var carbonIntensities = ArrayList<Double>()
     var carbonEmissions = ArrayList<Double>()
 
-    override fun record(reader: PowerSourceSample) {
+    override fun export(reader: PowerSourceSample) {
         powerDraws.add(reader.powerDraw)
         energyUsages.add(reader.energyUsage)
 

--- a/opendc-sdk/opendc-sdk-runner/src/test/kotlin/org/opendc/sdk/runner/base/harness/TestSupport.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/test/kotlin/org/opendc/sdk/runner/base/harness/TestSupport.kt
@@ -115,7 +115,7 @@ internal fun createTestTask(
 
 /**
  * Runs [workload] against [topology] on a fresh simulated clock with a one-minute export interval
- * and seed 0, returning the [TestComputeMonitor] that captured the run — the SDK-runner analogue of
+ * and seed 0, returning the [TestMetricExporter] that captured the run — the SDK-runner analogue of
  * the legacy `runTest`.
  */
 internal fun runTest(
@@ -126,8 +126,8 @@ internal fun runTest(
     checkpointModel: CheckpointSpec? = null,
     scalingPolicy: ScalingPolicySpec = ScalingPolicySpec.NoDelay,
     exportInterval: TimeDelta = TimeDelta.ofMin(1),
-): TestComputeMonitor {
-    val monitor = TestComputeMonitor()
+): TestMetricExporter {
+    val monitor = TestMetricExporter()
 //    val monitorSink = ParquetSink(Path.of("output"))
     val scenario =
         ScenarioSpec(

--- a/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/OpenDCRunner.kt
+++ b/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/OpenDCRunner.kt
@@ -46,7 +46,7 @@ import org.opendc.web.proto.runner.Report
 import org.opendc.web.proto.runner.Scenario
 import org.opendc.web.proto.runner.Topology
 import org.opendc.web.runner.internal.ReportCollector
-import org.opendc.web.runner.internal.WebComputeMonitor
+import org.opendc.web.runner.internal.WebMetricExporter
 import java.io.File
 import java.io.IOException
 import java.time.Duration
@@ -285,9 +285,9 @@ public class OpenDCRunner(
         private val scenario: Scenario,
         private val repeat: Int,
         private val topologyHosts: List<HostSpec>,
-    ) : RecursiveTask<WebComputeMonitor.Results>() {
-        override fun compute(): WebComputeMonitor.Results {
-            val monitor = WebComputeMonitor()
+    ) : RecursiveTask<WebMetricExporter.Results>() {
+        override fun compute(): WebMetricExporter.Results {
+            val monitor = WebMetricExporter()
 
             // Schedule task that interrupts the simulation if it runs for too long.
             val currentThread = Thread.currentThread()
@@ -306,7 +306,7 @@ public class OpenDCRunner(
         /**
          * Run a single simulation of the scenario.
          */
-        private fun runSimulation(monitor: WebComputeMonitor) =
+        private fun runSimulation(monitor: WebMetricExporter) =
             runSimulation {
                 val serviceDomain = "compute.opendc.org"
                 val seed = repeat.toLong()

--- a/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/internal/WebMetricExporter.kt
+++ b/opendc-web/opendc-web-runner/src/main/kotlin/org/opendc/web/runner/internal/WebMetricExporter.kt
@@ -22,16 +22,16 @@
 
 package org.opendc.web.runner.internal
 
-import org.opendc.sdk.runner.telemetry.ComputeMonitor
+import org.opendc.sdk.runner.telemetry.MetricExporter
 import org.opendc.sdk.runner.telemetry.table.host.HostSample
 import org.opendc.sdk.runner.telemetry.table.service.ServiceSample
 import kotlin.math.roundToLong
 
 /**
- * A [ComputeMonitor] that tracks the aggregate metrics for each repeat.
+ * A [MetricExporter] that tracks the aggregate metrics for each repeat.
  */
-internal class WebComputeMonitor : ComputeMonitor {
-    override fun record(reader: HostSample) {
+internal class WebMetricExporter : MetricExporter {
+    override fun export(reader: HostSample) {
         val slices = reader.downtime / sliceLength
 
         hostAggregateMetrics =
@@ -80,7 +80,7 @@ internal class WebComputeMonitor : ComputeMonitor {
 
     private lateinit var serviceData: ServiceSample
 
-    override fun record(reader: ServiceSample) {
+    override fun export(reader: ServiceSample) {
         serviceData = reader
     }
 


### PR DESCRIPTION
## Summary

Changed the workload datastructure to be a queue so the ServiceTasks are being deleted after being simulated.

Renamed the compute monitor and reader to exporter and sampler.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*