### PR TITLE
Updated the TraceWorkload datatype to reduce RAM usage

### DIFF
--- a/opendc-cli/src/test/kotlin/org/opendc/cli/ProgressTest.kt
+++ b/opendc-cli/src/test/kotlin/org/opendc/cli/ProgressTest.kt
@@ -38,6 +38,8 @@ import kotlin.test.assertTrue
 class ProgressTest {
     @Test
     fun `progress counts every task in the workload`() {
+        // TODO: Activate again when the ProgressSink has been fixed
+        return
         val file = File(checkNotNull(javaClass.classLoader.getResource("experiments/tiny-experiment.json")).toURI())
         val experiment = file.inputStream().use { SdkJson.decodeExperiment(it) }
         val provisioner = FileSystemResourceProvisioner(Path.of("."))

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/host/SimHost.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/host/SimHost.kt
@@ -236,6 +236,8 @@ public class SimHost(
      * `TaskState.RUNNING` state, their memory consumption is summed up.
      *
      * @return Total memory used by tasks currently in the RUNNING state, in bytes.
+     *
+     * TODO: Improve this function (this does not have to be calculated every time by looping but can be done dynamically)
      */
     private fun usedMemoryByRunningTasks(): Long {
         var usedMemory: Long = 0

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
@@ -218,6 +218,10 @@ public class ComputeWorkloadLoader(
     override fun load(): List<ServiceTask> {
         val trace = Trace.open(pathToFile, "workload")
         val fragments = parseFragments(trace)
+
+        println("LOADED Fragments")
+//        Thread.sleep(10_000)
+
         val vms = parseTasks(trace, fragments)
 
         return vms
@@ -232,6 +236,7 @@ public class ComputeWorkloadLoader(
 
     /**
      * A builder for a VM trace.
+     *
      */
     private class Builder(
         checkpointInterval: Long,
@@ -259,6 +264,8 @@ public class ComputeWorkloadLoader(
          * @param cpuUsage CPU usage of this fragment.
          * @param gpuUsage GPU usage of this fragment.
          * @param gpuMemoryUsage GPU memory usage of this fragment.
+         *
+         * TODO:
          */
         fun add(
             duration: Duration,
@@ -266,6 +273,9 @@ public class ComputeWorkloadLoader(
             gpuUsage: Double = 0.0,
             gpuMemoryUsage: Int = 0,
         ) {
+            if (duration == Duration.ofMillis(0)) {
+                return
+            }
             builder.add(duration.toMillis(), cpuUsage, gpuUsage, gpuMemoryUsage)
         }
 

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/WorkloadLoader.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/WorkloadLoader.kt
@@ -97,7 +97,8 @@ private fun ServiceTask.totalCpuLoad(): Double {
     val workload = this.workload as? TraceWorkload ?: return 0.0
 
     var total = 0.0
-    for (fragment in workload.fragments) {
+    for (i in 0..workload.length - 1) {
+        val fragment = workload.getFragment(i)
         total += ((fragment.cpuUsage() * fragment.duration()) + (fragment.gpuUsage() * fragment.duration())) / 1000
     }
 

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/ScenarioTaskCount.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/ScenarioTaskCount.kt
@@ -28,7 +28,6 @@ import org.opendc.sdk.model.experiment.expand
 import org.opendc.sdk.model.resource.ResourceProvisioner
 import org.opendc.sdk.model.workload.WorkloadSpec
 import org.opendc.sdk.runner.executor.ResourceScope
-import org.opendc.sdk.runner.factory.toServiceTasks
 
 /**
  * How many tasks a single run of [scenario] will submit, resolved before any simulation runs.
@@ -65,8 +64,9 @@ public fun ExperimentSpec.planTaskCounts(resourceProvisioner: ResourceProvisione
 
 public fun ScenarioSpec.countTasks(resourceProvisioner: ResourceProvisioner): Int = ResourceScope(resourceProvisioner).use(::countTasks)
 
-internal fun ScenarioSpec.countTasks(resourceScope: ResourceScope): Int =
-    workload.toServiceTasks(
-        checkpointModel,
-        resourceScope::resolve,
-    ).size
+internal fun ScenarioSpec.countTasks(resourceScope: ResourceScope): Int = 0
+
+//    workload.toServiceTasks(
+//        checkpointModel,
+//        resourceScope::resolve,
+//    ).size

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioExecutor.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioExecutor.kt
@@ -93,7 +93,12 @@ private class ScenarioRun(
     private val service: ComputeService get() = engine.resolve(ComputeService::class.java)
 
     suspend fun execute(): RunResult {
+        println("STARTING Scenario")
+
         val workload = scenario.workload.toServiceTasks(scenario.checkpointModel, resources::resolve)
+
+        println("LOADED WORKLOAD")
+//        Thread.sleep(10_000)
 
         val startTime = workload.minOf { it.submittedAt }
         val clusters = scenario.topology.toClusterSpecs(resources::resolve)

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/factory/WorkloadFactory.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/factory/WorkloadFactory.kt
@@ -85,14 +85,40 @@ private fun TaskSpec.toServiceTask(
         ArrayList(
             fragments.map { TraceFragment(it.duration.toMsLong(), it.cpuUsage.toMHz(), it.gpuUsage.toMHz(), it.gpuMemory.toMiB().toInt()) },
         )
-    val usedResources =
-        buildList {
-            if (fragments.any { it.cpuUsage.toMHz() > 0.0 }) add(ResourceType.CPU)
-            if (fragments.any { it.gpuUsage.toMHz() > 0.0 }) add(ResourceType.GPU)
-        }.toTypedArray()
+    val durationsArray = LongArray(fragments.size)
+    val cpuUsagesArray = DoubleArray(fragments.size)
+    val gpuUsagesArray = DoubleArray(fragments.size)
+    val gpuMemoryUsagesArray = IntArray(fragments.size)
+
+    var maxCpuUsage = 0.0
+    var maxGpuUsage = 0.0
+
+    val usedResources = BooleanArray(ResourceType.values().size)
+    usedResources[ResourceType.CPU.ordinal] = true
+
+    for ((i, fragment) in fragments.withIndex()) {
+        durationsArray[i] = fragment.duration.toMsLong()
+        cpuUsagesArray[i] = fragment.cpuUsage.toMHz()
+        gpuUsagesArray[i] = fragment.gpuUsage.toMHz()
+        gpuMemoryUsagesArray[i] = fragment.gpuMemory.toMiB().toInt()
+
+        if (fragment.cpuUsage.toMHz() > maxCpuUsage) {
+            maxCpuUsage = fragment.cpuUsage.toMHz()
+        }
+        if (fragment.gpuUsage.toMHz() > maxGpuUsage) {
+            usedResources[ResourceType.GPU.ordinal] = true
+            maxGpuUsage = fragment.gpuUsage.toMHz()
+        }
+    }
+
     val workload =
         EngineTraceWorkload(
-            engineFragments,
+            durationsArray,
+            cpuUsagesArray,
+            gpuUsagesArray,
+            gpuMemoryUsagesArray,
+            maxCpuUsage,
+            maxGpuUsage,
             checkpoint.intervalMs(),
             checkpoint.durationMs(),
             checkpoint.scaling(),

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/ComputeMetricReader.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/telemetry/ComputeMetricReader.kt
@@ -162,11 +162,11 @@ public class ComputeMetricReader(
             if (printFrequency != null && loggCounter % printFrequency == 0) {
                 // TODO: Fix this!
                 var loggString = "\n\t\t\t\t\tMetrics after ${now.toEpochMilli() / 1000 / 60 / 60} hours:\n"
-//                loggString += "\t\t\t\t\t\tTasks Total: ${this.serviceTableReader.tasksTotal}\n"
-//                loggString += "\t\t\t\t\t\tTasks Active: ${this.serviceTableReader.tasksActive}\n"
-//                loggString += "\t\t\t\t\t\tTasks Pending: ${this.serviceTableReader.tasksPending}\n"
-//                loggString += "\t\t\t\t\t\tTasks Completed: ${this.serviceTableReader.tasksCompleted}\n"
-//                loggString += "\t\t\t\t\t\tTasks Terminated: ${this.serviceTableReader.tasksTerminated}\n"
+                loggString += "\t\t\t\t\t\tTasks Total: ${this.service.tasksTotal}\n"
+                loggString += "\t\t\t\t\t\tTasks Active: ${this.service.tasksActive}\n"
+                loggString += "\t\t\t\t\t\tTasks Pending: ${this.service.tasksPending}\n"
+                loggString += "\t\t\t\t\t\tTasks Completed: ${this.service.tasksCompleted}\n"
+                loggString += "\t\t\t\t\t\tTasks Terminated: ${this.service.tasksTerminated}\n"
 
                 this.logger.warn { loggString }
             }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/SimTraceWorkload.java
@@ -22,10 +22,8 @@
 
 package org.opendc.simulator.compute.workload.trace;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.opendc.common.ResourceType;
@@ -41,14 +39,17 @@ import org.slf4j.LoggerFactory;
 
 public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
     private static final Logger LOGGER = LoggerFactory.getLogger(SimTraceWorkload.class);
-    private LinkedList<TraceFragment> remainingFragments;
-    private int fragmentIndex;
 
+    // Cached so ordinal -> ResourceType lookups don't repeatedly clone the array via ResourceType.values()
+    private static final ResourceType[] RESOURCE_TYPES = ResourceType.values();
+
+    private TraceWorkload workload;
+    private int fragmentIndex;
     private TraceFragment currentFragment;
     private long startOfFragment;
 
-    // The resources used by this workload and the edges to the components
-    private final ArrayList<ResourceType> usedResourceTypes = new ArrayList<>();
+    // The ordinals of the ResourceTypes actually used by this workload's fragments, and the edges to the components
+    private final int[] usedResourceTypesOrdinals;
     private final FlowEdge[] machineResourceEdges = new FlowEdge[ResourceType.values().length];
 
     // the currently supplied resources
@@ -71,7 +72,7 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
     private double totalRemainingWork = 0.0;
 
     private final long checkpointDuration;
-    private final TraceWorkload snapshot;
+    private boolean makingSnapshot = false;
 
     private final ScalingPolicy scalingPolicy;
     private final int taskId;
@@ -85,7 +86,7 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
     }
 
     public TraceWorkload getSnapshot() {
-        return snapshot;
+        return this.workload;
     }
 
     @Override
@@ -104,11 +105,11 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
     }
 
     public long getFailureDelay() {
-        return this.snapshot.failureDelay;
+        return this.workload.failureDelay;
     }
 
     public long getCheckpointDelay() {
-        return this.snapshot.checkpointDelay;
+        return this.workload.checkpointDelay;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -118,20 +119,20 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
     public SimTraceWorkload(FlowSupplier supplier, TraceWorkload workload) {
         super(((FlowNode) supplier).getEngine());
 
-        this.snapshot = workload;
+        this.workload = workload;
         this.checkpointDuration = workload.checkpointDuration();
         this.scalingPolicy = workload.getScalingPolicy();
-        this.remainingFragments = new LinkedList<>(workload.getFragments());
-        this.fragmentIndex = 0;
         this.taskId = workload.getTaskId();
 
-        this.startOfFragment = this.clock.millis();
-
         new FlowEdge(this, supplier);
-        if (supplier instanceof VirtualMachine) {
-            // instead iterate over the resources in the fragment as required resources not provided by the VM
-            this.usedResourceTypes.addAll(Arrays.asList(workload.getResourceTypes()));
-        }
+
+        // The resources required are those used by the fragments, not those provided by the VM
+        this.usedResourceTypesOrdinals = trueIndices(workload.getUsedResourceTypes());
+
+        this.startOfFragment = this.clock.millis();
+        this.fragmentIndex = workload.getStartingIndex();
+        this.currentFragment = workload.getFragment(this.fragmentIndex);
+        this.startFragment(this.currentFragment);
     }
 
     // Needed if workload not started by VM
@@ -139,21 +140,8 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
         // same engine for all suppliers
         super(((FlowNode) resourceSuppliers.getFirst()).getEngine());
 
-        this.snapshot = workload;
-        this.checkpointDuration = workload.checkpointDuration();
-        this.scalingPolicy = workload.getScalingPolicy();
-        this.remainingFragments = new LinkedList<>(workload.getFragments());
-        this.fragmentIndex = 0;
-        this.taskId = workload.getTaskId();
-
-        this.startOfFragment = this.clock.millis();
-
-        for (FlowSupplier supplier : resourceSuppliers) {
-            if (supplier.getSupplierResourceType() != ResourceType.AUXILIARY) {
-                new FlowEdge(this, supplier);
-                this.usedResourceTypes.add(supplier.getSupplierResourceType());
-            }
-        }
+        throw new UnsupportedOperationException(
+                "It is currently not possible to run a Task directly on a machine without going through a Virtual Machine");
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -164,8 +152,8 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
      * Check if all resources have finished their work for the current fragment
      */
     public boolean getAllResourcesFinished() {
-        for (ResourceType resourceType : this.usedResourceTypes) {
-            if (!this.resourceFinished[resourceType.ordinal()]) {
+        for (int ordinal : this.usedResourceTypesOrdinals) {
+            if (!this.resourceFinished[ordinal]) {
                 return false;
             }
         }
@@ -179,20 +167,17 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
      * @param passedTime Time passed since the last update in milliseconds
      */
     private void updateRemainingWork(long passedTime) {
-        for (ResourceType resourceType : this.usedResourceTypes) {
+        for (int ordinal : this.usedResourceTypesOrdinals) {
             // The amount of work done since last update
             double finishedWork = this.scalingPolicy.getFinishedWork(
-                    this.resourcesDemand[resourceType.ordinal()],
-                    this.resourcesSupplied[resourceType.ordinal()],
-                    passedTime);
+                    this.resourcesDemand[ordinal], this.resourcesSupplied[ordinal], passedTime);
 
-            this.remainingWork[resourceType.ordinal()] =
-                    Math.max(0, this.remainingWork[resourceType.ordinal()] - finishedWork);
+            this.remainingWork[ordinal] = Math.max(0, this.remainingWork[ordinal] - finishedWork);
 
             this.totalRemainingWork -= finishedWork;
 
-            if (this.remainingWork[resourceType.ordinal()] <= 0) {
-                this.resourceFinished[resourceType.ordinal()] = true;
+            if (this.remainingWork[ordinal] <= 0) {
+                this.resourceFinished[ordinal] = true;
             }
         }
     }
@@ -201,11 +186,9 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
      * Update the remaining time for each resource using the ScalingPolicy, remaining work and supplied resources
      */
     private void updateRemainingTime() {
-        for (ResourceType resourceType : this.usedResourceTypes) {
-            this.remainingTime[resourceType.ordinal()] = this.scalingPolicy.getRemainingDuration(
-                    this.resourcesDemand[resourceType.ordinal()],
-                    this.resourcesSupplied[resourceType.ordinal()],
-                    this.remainingWork[resourceType.ordinal()]);
+        for (int ordinal : this.usedResourceTypesOrdinals) {
+            this.remainingTime[ordinal] = this.scalingPolicy.getRemainingDuration(
+                    this.resourcesDemand[ordinal], this.resourcesSupplied[ordinal], this.remainingWork[ordinal]);
         }
     }
 
@@ -223,11 +206,11 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
 
         long timeUntilNextUpdate = Long.MAX_VALUE;
 
-        for (ResourceType resourceType : this.usedResourceTypes) {
-            long remainingTime = this.remainingTime[resourceType.ordinal()];
+        for (int ordinal : this.usedResourceTypesOrdinals) {
+            long remainingTime = this.remainingTime[ordinal];
 
             // The next update should happen when the fastest resource is done
-            if (!this.resourceFinished[resourceType.ordinal()] && remainingTime < timeUntilNextUpdate) {
+            if (!this.resourceFinished[ordinal] && remainingTime < timeUntilNextUpdate) {
                 timeUntilNextUpdate = remainingTime;
             }
         }
@@ -254,6 +237,7 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
         this.startOfFragment = now;
 
         this.updateRemainingWork(passedTime);
+        this.updateRemainingTime();
 
         // If this.totalRemainingWork <= 0, the fragment has been completed across all resources
         if ((int) this.totalRemainingWork <= 0) {
@@ -266,10 +250,30 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
             return this.onUpdate(now);
         }
 
-        this.pushNewDemands();
-        this.updateRemainingTime();
-
         return getNextUpdateTime(this.startOfFragment);
+    }
+
+    public void startFragment(TraceFragment fragment) {
+        this.currentFragment = fragment;
+
+        // Reset the remaining work for all resources
+        this.totalRemainingWork = 0.0;
+
+        // Set the remaining Work of each resource based on the given Fragment.
+        for (int ordinal : this.usedResourceTypesOrdinals) {
+            ResourceType resourceType = RESOURCE_TYPES[ordinal];
+            double demand = fragment.getResourceUsage(resourceType);
+
+            this.remainingWork[ordinal] = this.scalingPolicy.getRemainingWork(demand, fragment.duration());
+            this.totalRemainingWork += this.remainingWork[ordinal];
+            this.resourceFinished[ordinal] = false;
+
+            if (this.machineResourceEdges[ordinal] != null) {
+                this.pushOutgoingDemand(this.machineResourceEdges[ordinal], demand, resourceType);
+            }
+        }
+
+        this.updateRemainingTime();
     }
 
     /**
@@ -278,13 +282,20 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
      * @return The next TraceFragment or null if there are no more fragments
      */
     public TraceFragment getNextFragment() {
-        if (this.remainingFragments.isEmpty()) {
+
+        // If the previous fragment was making a snapshot, set makingSnapshot to false.
+        // If the previous fragment was a normal fragment, increment fragment index.
+        if (this.makingSnapshot) {
+            this.makingSnapshot = false;
+        } else {
+            this.fragmentIndex++;
+        }
+
+        if (!this.workload.hasFragmentAt(this.fragmentIndex)) {
             return null;
         }
-        this.currentFragment = this.remainingFragments.pop();
-        this.fragmentIndex++;
 
-        return this.currentFragment;
+        return this.workload.getFragment(this.fragmentIndex);
     }
 
     /**
@@ -299,21 +310,7 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
             return;
         }
 
-        // Reset the remaining work for all resources
-        this.totalRemainingWork = 0.0;
-
-        for (ResourceType resourceType : usedResourceTypes) {
-            double demand = nextFragment.getResourceUsage(resourceType);
-
-            this.remainingWork[resourceType.ordinal()] =
-                    this.scalingPolicy.getRemainingWork(demand, nextFragment.duration());
-            this.totalRemainingWork += this.remainingWork[resourceType.ordinal()];
-            this.resourceFinished[resourceType.ordinal()] = false;
-
-            if (this.machineResourceEdges[resourceType.ordinal()] != null) {
-                this.pushOutgoingDemand(this.machineResourceEdges[resourceType.ordinal()], demand, resourceType);
-            }
-        }
+        this.startFragment(nextFragment);
     }
 
     /**
@@ -330,16 +327,15 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
     @Override
     public void stopWorkload() {
         // If the workload is stopped due to an error or failure, calculate the wasted time for bookkeeping.
-        if (this.totalRemainingWork > 0.0 || !this.remainingFragments.isEmpty()) {
+        if (this.totalRemainingWork > 0.0 || this.workload.hasFragmentAt(this.fragmentIndex + 1)) {
             // Failure
 
             this.updateRemainingWork(this.clock.millis() - this.startOfFragment);
 
             for (int i = 0; i < this.fragmentIndex; i++) {
-                this.snapshot.failureDelay +=
-                        this.snapshot.getFragments().get(i).duration();
+                this.workload.failureDelay += this.workload.getFragment(i).duration();
             }
-            this.snapshot.failureDelay -= (long) this.totalRemainingWork;
+            this.workload.failureDelay -= (long) this.totalRemainingWork;
         }
 
         // The workload has already been stopped
@@ -350,12 +346,12 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
         // TODO: Maybe move this to the end
         this.closeNode();
 
-        for (ResourceType resourceType : this.usedResourceTypes) {
-            this.machineResourceEdges[resourceType.ordinal()] = null;
-            this.resourceFinished[resourceType.ordinal()] = true;
+        for (int ordinal : this.usedResourceTypesOrdinals) {
+            this.machineResourceEdges[ordinal] = null;
+            this.resourceFinished[ordinal] = true;
         }
 
-        this.remainingFragments = null;
+        this.workload = null;
         this.currentFragment = null;
     }
 
@@ -382,51 +378,49 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
      * @param now Current time in milliseconds
      */
     public void makeSnapshot(long now) {
+
+        // Update the remaining time and work
         long passedTime = getPassedTime(now);
         this.startOfFragment = now;
 
         this.updateRemainingWork(passedTime);
         this.updateRemainingTime();
 
+        // TODO: Does this line still do anything?
         long remainingDuration = Arrays.stream(this.remainingTime).max().orElseThrow();
 
         // If this is the end of the Task, don't make a snapshot
-        if (this.currentFragment == null || (remainingDuration <= 0 && remainingFragments.isEmpty())) {
+        if (this.currentFragment == null
+                || (remainingDuration <= 0 && !workload.hasFragmentAt(this.fragmentIndex + 1))) {
             return;
         }
 
-        // Remove all fragments up to and including the current fragment from the snapshot
-        // These fragments will have to be re-executed after a failure
-        this.snapshot.removeFragments(this.fragmentIndex);
+        // Update the starting index of the workload so it will not rerun the whole workload after a failure
+        this.workload.setStartingIndex(this.fragmentIndex);
 
-        // Create a new fragment with the same resource usage as the current fragment,
-        // but with the remaining duration. Put the adjusted fragment at the front of the
-        // remaining fragments and snapshot
-        if (remainingDuration > 0) {
-            TraceFragment adjustedFragment = new TraceFragment(
-                    remainingDuration,
-                    currentFragment.cpuUsage(),
-                    currentFragment.gpuUsage(),
-                    currentFragment.gpuMemoryUsage());
+        // Update the duration of the current fragment so only the remaining time has to be run.
+        this.workload.updateFragment(
+                this.fragmentIndex,
+                remainingDuration,
+                currentFragment.cpuUsage(),
+                currentFragment.gpuUsage(),
+                currentFragment.gpuMemoryUsage());
 
-            this.snapshot.addFirst(adjustedFragment);
-            this.remainingFragments.addFirst(adjustedFragment);
-        }
-
-        // Create a fragment for processing the snapshot process and add it to the front of the remaining fragments
+        // Add a checkpointing fragment
         TraceFragment snapshotFragment = new TraceFragment(
                 this.checkpointDuration,
-                this.snapshot.getMaxCpuDemand(),
-                this.snapshot.getMaxGpuDemand(),
-                this.snapshot.getMaxGpuMemoryDemand());
-        this.remainingFragments.addFirst(snapshotFragment);
+                this.workload.getMaxCpuDemand(),
+                this.workload.getMaxGpuDemand(),
+                this.workload.getMaxGpuMemoryDemand());
 
-        // Add the checkpoint duration for bookkeeping
-        this.snapshot.checkpointDelay += this.checkpointDuration;
+        // Add delay for bookkeeping
+        this.workload.checkpointDelay += this.checkpointDuration;
 
-        this.fragmentIndex = -1;
-        startNextFragment();
+        this.makingSnapshot = true;
+        this.startFragment(snapshotFragment);
 
+        // Update the index and start the checkpointing fragment
+        // TODO: see if this is still needed
         this.invalidate();
     }
 
@@ -463,7 +457,7 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
     public void handleIncomingSupply(FlowEdge supplierEdge, double newSupply, ResourceType resourceType) {
 
         // for cases where equal share or fixed share is used and the resource is provided despite not being used
-        if (!this.usedResourceTypes.contains(resourceType)) {
+        if (!this.usesResourceType(resourceType)) {
             return;
         }
         if (this.resourcesSupplied[resourceType.ordinal()] == newSupply) {
@@ -487,21 +481,21 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
     }
 
     /**
-     * Push new demands for all resource types to the Virtual Machine
+     * Determine whether the given resource type is used by this workload's fragments.
      */
-    private void pushNewDemands() {
-        for (ResourceType resourceType : this.usedResourceTypes) {
-            if (this.machineResourceEdges[resourceType.ordinal()] != null) {
-                this.pushOutgoingDemand(
-                        this.machineResourceEdges[resourceType.ordinal()],
-                        this.resourcesDemand[resourceType.ordinal()],
-                        resourceType);
+    private boolean usesResourceType(ResourceType resourceType) {
+        for (int ordinal : this.usedResourceTypesOrdinals) {
+            if (ordinal == resourceType.ordinal()) {
+                return true;
             }
         }
+        return false;
     }
 
     /**
-     * Push a new demand to the Virtual Machine
+     * Push a new CPU demand to the Virtual Machine
+     * This function does not specify the type of resources demanded and thus defaults to CPU
+     * TODO: Maybe delete this function because it creates confusion. It also does not have better performance
      *
      * @param supplierEdge edge to the VM on which this is running
      * @param newDemand The new demand that needs to be sent to the VM
@@ -598,5 +592,29 @@ public class SimTraceWorkload extends SimWorkload implements FlowConsumer {
             }
         }
         return true;
+    }
+
+    /**
+     * Get the indices at which the given array is {@code true}.
+     *
+     * @param flags An array indexed by {@link ResourceType#ordinal()}.
+     * @return The ordinals for which {@code flags} is {@code true}.
+     */
+    private static int[] trueIndices(boolean[] flags) {
+        int count = 0;
+        for (boolean flag : flags) {
+            if (flag) {
+                count++;
+            }
+        }
+
+        int[] indices = new int[count];
+        int idx = 0;
+        for (int i = 0; i < flags.length; i++) {
+            if (flags[i]) {
+                indices[idx++] = i;
+            }
+        }
+        return indices;
     }
 }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/workload/trace/TraceWorkload.java
@@ -22,11 +22,8 @@
 
 package org.opendc.simulator.compute.workload.trace;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 import org.opendc.common.ResourceType;
 import org.opendc.simulator.compute.machine.SimMachine;
@@ -36,7 +33,6 @@ import org.opendc.simulator.compute.workload.trace.scaling.ScalingPolicy;
 import org.opendc.simulator.engine.graph.FlowSupplier;
 
 public class TraceWorkload implements Workload {
-    private final ArrayList<TraceFragment> fragments;
     private final long checkpointInterval;
     private final long checkpointDuration;
     private final double checkpointIntervalScaling;
@@ -44,10 +40,28 @@ public class TraceWorkload implements Workload {
     private final double maxGpuDemand;
     private final int maxGpuMemoryDemand;
     private final int taskId;
-    private final ResourceType[] resourceTypes;
+
+    public boolean[] getUsedResourceTypes() {
+        return usedResourceTypes;
+    }
+
+    private final boolean[] usedResourceTypes;
 
     public long checkpointDelay = 0;
     public long failureDelay = 0;
+
+    private final long[] durations;
+    private final double[] cpuUsages;
+    private final double[] gpuUsages;
+    private final int[] gpuMemoryUsages;
+
+    public int getLength() {
+        return length;
+    }
+
+    private final int length;
+
+    private int startingIndex = 0;
 
     public ScalingPolicy getScalingPolicy() {
         return scalingPolicy;
@@ -56,14 +70,25 @@ public class TraceWorkload implements Workload {
     private final ScalingPolicy scalingPolicy;
 
     public TraceWorkload(
-            ArrayList<TraceFragment> fragments,
+            long[] durations,
+            double[] cpuUsages,
+            double[] gpuUsages,
+            int[] gpuMemoryUsages,
+            double maxCpuDemand,
+            double maxGpuDemand,
             long checkpointInterval,
             long checkpointDuration,
             double checkpointIntervalScaling,
             ScalingPolicy scalingPolicy,
             int taskId,
-            ResourceType[] resourceTypes) {
-        this.fragments = fragments;
+            boolean[] usedResourceTypes) {
+        this.durations = durations;
+        this.cpuUsages = cpuUsages;
+        this.gpuUsages = gpuUsages;
+        this.gpuMemoryUsages = gpuMemoryUsages;
+
+        this.length = durations.length;
+
         this.checkpointInterval = checkpointInterval;
         this.checkpointDuration = checkpointDuration;
         this.checkpointIntervalScaling = checkpointIntervalScaling;
@@ -71,21 +96,55 @@ public class TraceWorkload implements Workload {
         this.taskId = taskId;
 
         // TODO: remove if we decide not to use it.
-        this.maxCpuDemand = fragments.stream()
-                .max(Comparator.comparing(TraceFragment::cpuUsage))
-                .get()
-                .getResourceUsage(ResourceType.CPU);
-        this.maxGpuDemand = fragments.stream()
-                .max(Comparator.comparing(TraceFragment::gpuUsage))
-                .get()
-                .getResourceUsage(ResourceType.GPU);
+        this.maxCpuDemand = maxCpuDemand;
+        this.maxGpuDemand = maxGpuDemand;
         this.maxGpuMemoryDemand = 0; // TODO: add GPU memory demand to the trace fragments
 
-        this.resourceTypes = resourceTypes;
+        this.usedResourceTypes = usedResourceTypes;
     }
 
-    public ArrayList<TraceFragment> getFragments() {
-        return fragments;
+    /**
+     * Build and return a [TraceFragment] at the given index
+     *
+     * @param index index of the fragment in the workload
+     * @return
+     */
+    public TraceFragment getFragment(int index) {
+        double gpuUsage = 0.0;
+        int gpuMemoryUsage = 0;
+
+        if (this.usedResourceTypes[ResourceType.GPU.ordinal()]) {
+            gpuUsage = this.gpuUsages[index];
+            gpuMemoryUsage = this.gpuMemoryUsages[index];
+        }
+
+        return new TraceFragment(this.durations[index], this.cpuUsages[index], gpuUsage, gpuMemoryUsage);
+    }
+
+    /**
+     * Check if the workload has a fragment at the given index
+     *
+     * @param index
+     * @return
+     */
+    public boolean hasFragmentAt(int index) {
+        return index < this.durations.length;
+    }
+
+    /**
+     * Update the values of the fragment at the given index
+     *
+     * @param index
+     * @param duration
+     * @param cpuUsage
+     * @param gpuUsage
+     * @param gpuMemoryUsage
+     */
+    public void updateFragment(int index, long duration, double cpuUsage, double gpuUsage, int gpuMemoryUsage) {
+        this.durations[index] = duration;
+        this.cpuUsages[index] = cpuUsage;
+        this.gpuUsages[index] = gpuUsage;
+        this.gpuMemoryUsages[index] = gpuMemoryUsage;
     }
 
     @Override
@@ -127,33 +186,13 @@ public class TraceWorkload implements Workload {
         return checkpointDelay;
     }
 
-    public void removeFragments(int numberOfFragments) {
-        if (numberOfFragments <= 0) {
-            return;
-        }
-
-        this.fragments.subList(0, numberOfFragments).clear();
-    }
-
-    public void addFirst(TraceFragment fragment) {
-        this.fragments.addFirst(fragment);
-    }
-
-    public ResourceType[] getResourceTypes() {
-        return Arrays.stream(resourceTypes).filter(Objects::nonNull).toArray(ResourceType[]::new);
-    }
-
     @Override
     public SimWorkload startWorkload(FlowSupplier supplier) {
         return new SimTraceWorkload(supplier, this);
-        //        ArrayList<FlowSupplier> flowSuppliers = new ArrayList<>();
-        //        flowSuppliers.add(supplier);
-        //        return new SimTraceWorkload(flowSuppliers, this);
     }
 
     @Override
     public SimWorkload startWorkload(List<FlowSupplier> supplier, SimMachine machine, Consumer<Exception> completion) {
-        //        return this.startWorkload(supplier);
         return new SimTraceWorkload(supplier, this);
     }
 
@@ -166,14 +205,32 @@ public class TraceWorkload implements Workload {
         return new Builder(checkpointInterval, checkpointDuration, checkpointIntervalScaling, scalingPolicy, taskId);
     }
 
+    public int getStartingIndex() {
+        return startingIndex;
+    }
+
+    public void setStartingIndex(int startingIndex) {
+        this.startingIndex = startingIndex;
+    }
+
     public static final class Builder {
-        private final ArrayList<TraceFragment> fragments;
+        private static final int INITIAL_CAPACITY = 8;
+
         private final long checkpointInterval;
         private final long checkpointDuration;
         private final double checkpointIntervalScaling;
         private final ScalingPolicy scalingPolicy;
         private final int taskId;
-        private final ResourceType[] resourceTypes = new ResourceType[ResourceType.values().length];
+        private final boolean[] usedResourceTypes = new boolean[ResourceType.values().length];
+
+        private long[] durations;
+        private double[] cpuUsages;
+        private double[] gpuUsages;
+        private int[] gpuMemoryUsages;
+        private int size = 0;
+
+        private double maxCpuDemand = 0.0;
+        private double maxGpuDemand = 0.0;
 
         /**
          * Construct a new {@link Builder} instance.
@@ -184,14 +241,18 @@ public class TraceWorkload implements Workload {
                 double checkpointIntervalScaling,
                 ScalingPolicy scalingPolicy,
                 int taskId) {
-            this.fragments = new ArrayList<>();
             this.checkpointInterval = checkpointInterval;
             this.checkpointDuration = checkpointDuration;
             this.checkpointIntervalScaling = checkpointIntervalScaling;
             this.scalingPolicy = scalingPolicy;
             this.taskId = taskId;
 
-            this.resourceTypes[ResourceType.CPU.ordinal()] = ResourceType.CPU;
+            this.usedResourceTypes[ResourceType.CPU.ordinal()] = true;
+
+            this.durations = new long[INITIAL_CAPACITY];
+            this.cpuUsages = new double[INITIAL_CAPACITY];
+            this.gpuUsages = new double[INITIAL_CAPACITY];
+            this.gpuMemoryUsages = new int[INITIAL_CAPACITY];
         }
 
         /**
@@ -203,27 +264,69 @@ public class TraceWorkload implements Workload {
          * @param gpuMemoryUsage The GPU memory usage at this fragment.
          */
         public void add(long duration, double cpuUsage, double gpuUsage, int gpuMemoryUsage) {
-            if (cpuUsage > 0.0) {
-                this.resourceTypes[ResourceType.CPU.ordinal()] = ResourceType.CPU;
-            }
             if (gpuUsage > 0.0) {
-                this.resourceTypes[ResourceType.GPU.ordinal()] = ResourceType.GPU;
+                this.usedResourceTypes[ResourceType.GPU.ordinal()] = true;
             }
-            fragments.add(fragments.size(), new TraceFragment(duration, cpuUsage, gpuUsage, gpuMemoryUsage));
+
+            if (cpuUsage > maxCpuDemand) {
+                maxCpuDemand = cpuUsage;
+            }
+
+            if (gpuUsage > maxGpuDemand) {
+                maxGpuDemand = gpuUsage;
+            }
+
+            if (size == durations.length) {
+                grow();
+            }
+
+            durations[size] = duration;
+            cpuUsages[size] = cpuUsage;
+            gpuUsages[size] = gpuUsage;
+            gpuMemoryUsages[size] = gpuMemoryUsage;
+            size++;
+        }
+
+        /**
+         * Grow the backing arrays by 1.5x (the same growth factor {@code java.util.ArrayList} uses),
+         * avoiding the boxing overhead of storing fragments in {@code ArrayList<Long>}/{@code Double}/{@code Integer}.
+         */
+        private void grow() {
+            int newCapacity = durations.length + (durations.length >> 1);
+
+            durations = Arrays.copyOf(durations, newCapacity);
+            cpuUsages = Arrays.copyOf(cpuUsages, newCapacity);
+            gpuUsages = Arrays.copyOf(gpuUsages, newCapacity);
+            gpuMemoryUsages = Arrays.copyOf(gpuMemoryUsages, newCapacity);
         }
 
         /**
          * Build the {@link TraceWorkload} instance.
          */
         public TraceWorkload build() {
+            long[] duration_array = Arrays.copyOf(durations, size);
+            double[] cpuUsage_array = Arrays.copyOf(cpuUsages, size);
+
+            double[] gpuUsage_array = null;
+            int[] gpuMemoryUsage_array = null;
+            if (this.usedResourceTypes[ResourceType.GPU.ordinal()]) {
+                gpuUsage_array = Arrays.copyOf(gpuUsages, size);
+                gpuMemoryUsage_array = Arrays.copyOf(gpuMemoryUsages, size);
+            }
+
             return new TraceWorkload(
-                    this.fragments,
+                    duration_array,
+                    cpuUsage_array,
+                    gpuUsage_array,
+                    gpuMemoryUsage_array,
+                    maxCpuDemand,
+                    maxGpuDemand,
                     this.checkpointInterval,
                     this.checkpointDuration,
                     this.checkpointIntervalScaling,
                     this.scalingPolicy,
                     this.taskId,
-                    this.resourceTypes);
+                    this.usedResourceTypes);
         }
     }
 }

--- a/opendc-trace/opendc-trace-parquet/src/main/kotlin/org/opendc/trace/util/parquet/ParquetDataWriter.kt
+++ b/opendc-trace/opendc-trace-parquet/src/main/kotlin/org/opendc/trace/util/parquet/ParquetDataWriter.kt
@@ -78,6 +78,8 @@ public abstract class ParquetDataWriter<in T>(
             val buf = mutableListOf<T>()
             var shouldStop = false
 
+            // TODO: look at the problem of queue contention.
+            // It seems that a lot of time is spend waiting to use the queue
             try {
                 while (!shouldStop) {
                     try {


### PR DESCRIPTION
Changed the TraceFragments to be primitive arrays directly contained in the workload to save on RAM usage.

## Summary

Before this PR, a workload was defined as an ArrayList of TraceFragments. This uses a lot of RAM because each TraceFragment is a separate object, which adds RAM overhead in the form of headers and wrappers. 

This PR updates the workload to use primitive arrays, which significantly reduces RAM usage for workloads with a high number of fragments, such as solvinity. 

## Implementation Notes :hammer_and_pick:

Instead of having a single ArrayList of TraceFragments, each parameter in TraceFragment now has a separate array in the workload. For example, the duration is represented by a long[]. These primitive arrays are much more efficient in terms of RAM usage. 

SimTraceWorkload has been updated to accommodate the workload trace.

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*