### PR TITLE
Changed default path to be the working directory and added input-root as a parameter.

### DIFF
--- a/opendc-cli/src/main/kotlin/org/opendc/cli/ExperimentImports.kt
+++ b/opendc-cli/src/main/kotlin/org/opendc/cli/ExperimentImports.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import org.opendc.sdk.model.experiment.ExperimentSpec
 import org.opendc.sdk.model.serialization.SdkJson
 import java.io.File
+import java.nio.file.Path
 
 /** The key that names the file an object takes the rest of its fields from. */
 private const val IMPORT_KEY = "importFrom"
@@ -63,11 +64,12 @@ private const val IMPORT_KEY = "importFrom"
  */
 internal fun readExperiment(
     file: File,
+    baseDir: File = Path.of("").toAbsolutePath().toFile(),
     strict: Boolean = false,
 ): ExperimentSpec {
     val start = file.canonicalFile
     val document = SdkJson.json.parseToJsonElement(start.readText()).asImportable(start)
-    return SdkJson.fromJsonElement(document.resolveImports(start.parentFile, listOf(start)), strict)
+    return SdkJson.fromJsonElement(document.resolveImports(baseDir, listOf(start)), strict)
 }
 
 /** Signals an `importFrom` that cannot be resolved. */

--- a/opendc-cli/src/main/kotlin/org/opendc/cli/Main.kt
+++ b/opendc-cli/src/main/kotlin/org/opendc/cli/Main.kt
@@ -34,6 +34,7 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.file
+import com.github.ajalt.clikt.parameters.types.path
 import com.github.ajalt.mordant.terminal.Terminal
 import org.opendc.cli.config.CliConfig
 import org.opendc.cli.config.toMordantTheme
@@ -68,10 +69,17 @@ internal class OpendcCommand : CliktCommand(name = "opendc") {
         help = "Reject experiment files that contain unknown keys instead of ignoring them.",
     ).flag()
 
+    private val inputRoot by option(
+        "--input-root",
+        help =
+            "Root for resolving named/relative topology, workload and trace references " +
+                "(default: the experiment file's directory, or the working directory under --legacy).",
+    ).path(canBeFile = false, mustExist = false)
+
     override fun help(context: Context): String = "Run, validate and inspect OpenDC datacenter simulations."
 
     override fun run() {
-        currentContext.obj = ExperimentReadOptions(legacy = legacy, strict = strict)
+        currentContext.obj = ExperimentReadOptions(legacy = legacy, strict = strict, inputRoot = inputRoot)
     }
 }
 
@@ -82,6 +90,7 @@ internal class OpendcCommand : CliktCommand(name = "opendc") {
 internal data class ExperimentReadOptions(
     val legacy: Boolean,
     val strict: Boolean,
+    val inputRoot: Path?,
 )
 
 /**
@@ -105,15 +114,19 @@ internal abstract class ExperimentCommand(
     protected val isStrict: Boolean
         get() = currentContext.findObject<ExperimentReadOptions>()?.strict == true
 
+    /** Whether the root command was asked to reject experiments that carry unknown keys. */
+    protected val inputRoot: Path?
+        get() = currentContext.findObject<ExperimentReadOptions>()?.inputRoot
+
     /**
      * The directory the experiment should be resolved at
      */
     protected val experimentBaseDirectory: Path
         get() =
-            if (isLegacy) {
-                Path.of("").toAbsolutePath()
+            if (inputRoot != null) {
+                inputRoot!!
             } else {
-                experimentFile.absoluteFile.parentFile.toPath()
+                Path.of("").toAbsolutePath()
             }
 
     /**
@@ -123,12 +136,12 @@ internal abstract class ExperimentCommand(
      * [root]; otherwise it is SDK-model JSON, which composes the files it names with `importFrom`
      * relative to itself and so needs no root.
      */
-    protected fun loadExperiment(): ExperimentSpec =
+    protected fun loadExperiment(rootPath: Path = experimentBaseDirectory): ExperimentSpec =
         try {
             if (isLegacy) {
-                readLegacyExperiment(experimentFile, experimentBaseDirectory.toFile(), isStrict)
+                readLegacyExperiment(experimentFile, rootPath.toFile(), isStrict)
             } else {
-                readExperiment(experimentFile, isStrict)
+                readExperiment(experimentFile, rootPath.toFile(), isStrict)
             }
         } catch (e: Exception) {
             throw CliktError(

--- a/opendc-cli/src/main/kotlin/org/opendc/cli/legacy/LegacyExperiment.kt
+++ b/opendc-cli/src/main/kotlin/org/opendc/cli/legacy/LegacyExperiment.kt
@@ -32,6 +32,7 @@ import kotlinx.serialization.json.buildJsonObject
 import org.opendc.sdk.model.experiment.ExperimentSpec
 import org.opendc.sdk.model.serialization.SdkJson
 import java.io.File
+import java.nio.file.Path
 
 /**
  * Reads an experiment written in the deprecated `opendc-experiments-base` JSON format, the format the
@@ -60,7 +61,7 @@ import java.io.File
  */
 internal fun readLegacyExperiment(
     file: File,
-    baseDir: File,
+    baseDir: File = Path.of("").toAbsolutePath().toFile(),
     strict: Boolean = false,
 ): ExperimentSpec {
     val document = SdkJson.json.parseToJsonElement(file.readText()).asObject("the experiment")

--- a/opendc-cli/src/test/kotlin/org/opendc/cli/CliTest.kt
+++ b/opendc-cli/src/test/kotlin/org/opendc/cli/CliTest.kt
@@ -84,7 +84,18 @@ class CliTest {
     fun `run simulates an experiment that imports its topology and workload`() {
         val out = createTempDirectory("opendc-cli-imports")
         try {
-            val result = opendc().test(listOf("run", imports, "-o", out.toString(), "--no-progress"))
+            val result =
+                opendc().test(
+                    listOf(
+                        "--input-root",
+                        "build/resources/test/experiments/imports",
+                        "run",
+                        imports,
+                        "-o",
+                        out.toString(),
+                        "--no-progress",
+                    ),
+                )
             assertEquals(0, result.statusCode, result.output)
             val parquet = out.toFile().walkTopDown().filter { it.extension == "parquet" }.toList()
             assertTrue(parquet.isNotEmpty(), "expected parquet output under $out")
@@ -96,7 +107,15 @@ class CliTest {
     /** `show` renders the imported topology, proving the import is resolved before anything reads it. */
     @Test
     fun `show prints a topology pulled in with importFrom`() {
-        val result = opendc().test(listOf("show", imports))
+        val result =
+            opendc().test(
+                listOf(
+                    "--input-root",
+                    "build/resources/test/experiments/imports",
+                    "show",
+                    imports,
+                ),
+            )
         assertEquals(0, result.statusCode, result.output)
         assertContains(result.stdout, "big-host")
     }

--- a/opendc-cli/src/test/kotlin/org/opendc/cli/ExperimentImportsTest.kt
+++ b/opendc-cli/src/test/kotlin/org/opendc/cli/ExperimentImportsTest.kt
@@ -29,6 +29,7 @@ import org.opendc.sdk.model.experiment.ExperimentSpec
 import org.opendc.sdk.model.topology.PowerModelType
 import org.opendc.sdk.model.workload.InlineWorkloadSpec
 import java.io.File
+import java.nio.file.Path
 import kotlin.io.path.createTempDirectory
 import kotlin.test.Test
 import kotlin.test.assertContains
@@ -45,7 +46,11 @@ class ExperimentImportsTest {
     /** The headline: a topology written in its own file, pulled into an experiment. */
     @Test
     fun `an experiment imports its topology from another file`() {
-        val experiment = load("experiments/imports/experiment.json")
+        val experiment =
+            load(
+                "experiments/imports/experiment.json",
+                Path.of("build/resources/test/experiments/imports"),
+            )
 
         val cluster = experiment.topologies.single().clusters.single()
         assertEquals("cluster", cluster.name)
@@ -63,7 +68,11 @@ class ExperimentImportsTest {
     /** Any object may be imported, not just a topology — here the workload is a file of its own. */
     @Test
     fun `an experiment imports its workload from another file`() {
-        val workload = load("experiments/imports/experiment.json").workloads.single()
+        val workload =
+            load(
+                "experiments/imports/experiment.json",
+                Path.of("build/resources/test/experiments/imports"),
+            ).workloads.single()
 
         assertEquals(listOf(0, 1), (workload as InlineWorkloadSpec).tasks.map { it.id })
     }
@@ -74,7 +83,11 @@ class ExperimentImportsTest {
      */
     @Test
     fun `a key written next to the import overrides the imported one`() {
-        val host = load("experiments/imports/experiment.json").topologies.single().clusters.single().hosts.single()
+        val host =
+            load(
+                "experiments/imports/experiment.json",
+                Path.of("build/resources/test/experiments/imports"),
+            ).topologies.single().clusters.single().hosts.single()
 
         assertEquals(4, host.count, "the topology's own count overrides the one in the imported host")
         assertEquals("big-host", host.name, "everything it does not override still comes from the import")
@@ -88,7 +101,11 @@ class ExperimentImportsTest {
     @Test
     fun `imports nest and resolve against the file that declares them`() {
         // Loading at all proves it: the host lives a directory deeper than the file that imports it.
-        val host = load("experiments/imports/experiment.json").topologies.single().clusters.single().hosts.single()
+        val host =
+            load(
+                "experiments/imports/experiment.json",
+                Path.of("build/resources/test/experiments/imports"),
+            ).topologies.single().clusters.single().hosts.single()
 
         assertEquals(8, host.cpu.coreCount)
     }
@@ -116,11 +133,14 @@ class ExperimentImportsTest {
         File(root, "a.json").writeText("""{ "importFrom": "b.json" }""")
         File(root, "b.json").writeText("""{ "importFrom": "a.json" }""")
 
-        val error = assertFailsWith<ImportException> { readExperiment(File(root, "a.json")) }
+        val error = assertFailsWith<ImportException> { readExperiment(File(root, "a.json"), root) }
         assertContains(error.message.orEmpty(), "imports itself")
     }
 
-    private fun load(resource: String): ExperimentSpec = readExperiment(resourceFile(resource))
+    private fun load(
+        resource: String,
+        rootPath: Path = Path.of(""),
+    ): ExperimentSpec = readExperiment(resourceFile(resource), rootPath.toFile())
 
     private fun resourceFile(name: String): File =
         File(checkNotNull(javaClass.classLoader.getResource(name)) { "missing fixture $name" }.toURI())

--- a/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioExecutor.kt
+++ b/opendc-sdk/opendc-sdk-runner/src/main/kotlin/org/opendc/sdk/runner/executor/ScenarioExecutor.kt
@@ -93,12 +93,7 @@ private class ScenarioRun(
     private val service: ComputeService get() = engine.resolve(ComputeService::class.java)
 
     suspend fun execute(): RunResult {
-        println("STARTING Scenario")
-
         val workload = scenario.workload.toServiceTasks(scenario.checkpointModel, resources::resolve)
-
-        println("LOADED WORKLOAD")
-//        Thread.sleep(10_000)
 
         val startTime = workload.minOf { it.submittedAt }
         val clusters = scenario.topology.toClusterSpecs(resources::resolve)


### PR DESCRIPTION
## Summary

Changed the default path used for importing files to the working directory and added input-root as a parameter.
Added --input-root to Main.kt, which can be used to change the input root of the import files.

## Implementation Notes :hammer_and_pick:

* Briefly outline the overall technical solution. If necessary, identify talking points where the reviewer's attention should be drawn to.

## External Dependencies :four_leaf_clover:

* 

## Breaking API Changes :warning:

* 

*Simply specify none (N/A) if not applicable.*