### PR TITLE
Moved the creation of the OpenDCExperimentRunner to opendc-cli

### DIFF
--- a/opendc-cli/README.md
+++ b/opendc-cli/README.md
@@ -8,21 +8,13 @@ executable that runs, validates and inspects experiment files.
 Build a runnable distribution and put it on your `PATH`:
 
 ```bash
-./gradlew :opendc-cli:installDist
-export PATH=$PATH:$(realpath opendc-cli/build/install/opendc/bin)
+./gradlew :opendc-cli:distTar
+tar -xf opendc-cli/build/distributions/OpenDCExperimentRunner.tar -C opendc-cli/build/distributions
+export PATH=$PATH:$(realpath opendc-cli/build/distributions/OpenDCExperimentRunner/bin)
 ```
 
-You can now call `opendc` from anywhere. Re-run `installDist` after code changes to refresh the
-binary.
-
-Alternatively, run without installing:
-
-```bash
-./gradlew :opendc-cli:run --args="run experiment.json"
-```
-
-Gradle captures the process output, so the live progress dashboard does not render as an interactive
-terminal this way. Prefer the installed binary for normal use.
+You can now call `opendc` from anywhere. Re-run the two commands above after code changes to refresh
+the binary.
 
 ## Experiment file
 

--- a/opendc-cli/build.gradle.kts
+++ b/opendc-cli/build.gradle.kts
@@ -3,17 +3,8 @@ description = "Command-line interface for running OpenDC simulations"
 plugins {
     `kotlin-conventions`
     `testing-conventions`
-    application
     id("me.champeau.jmh")
-}
-
-group = "org.opendc"
-version = "3.0-SNAPSHOT"
-
-application {
-    applicationName = "opendc"
-    mainClass.set("org.opendc.cli.MainKt")
-    applicationDefaultJvmArgs = listOf("-XX:MaxRAMPercentage=90.0")
+    distribution
 }
 
 jmh {
@@ -65,4 +56,37 @@ dependencies {
     runtimeOnly(libs.log4j.slf4j)
 
     testImplementation(kotlin("test"))
+}
+
+val createScenarioApp by tasks.creating(CreateStartScripts::class) {
+    dependsOn(tasks.jar)
+
+    applicationName = "opendc"
+    mainClass.set("org.opendc.cli.MainKt")
+    defaultJvmOpts = listOf("-XX:MaxRAMPercentage=90.0")
+    classpath = tasks.jar.get().outputs.files + configurations["runtimeClasspath"]
+    outputDir = layout.buildDirectory.dir("scenarioScripts").get().asFile
+}
+
+// Create custom Scenario distribution
+distributions {
+    main {
+        distributionBaseName.set("OpenDCExperimentRunner")
+
+        contents {
+            from("README.md")
+            from("../LICENSE.txt")
+
+            into("bin") {
+                from(createScenarioApp) {
+                    include("opendc", "opendc.bat")
+                }
+            }
+
+            into("lib") {
+                from(tasks.jar)
+                from(configurations["runtimeClasspath"])
+            }
+        }
+    }
 }

--- a/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
+++ b/opendc-compute/opendc-compute-workload/src/main/kotlin/org/opendc/compute/workload/ComputeWorkloadLoader.kt
@@ -219,9 +219,6 @@ public class ComputeWorkloadLoader(
         val trace = Trace.open(pathToFile, "workload")
         val fragments = parseFragments(trace)
 
-        println("LOADED Fragments")
-//        Thread.sleep(10_000)
-
         val vms = parseTasks(trace, fragments)
 
         return vms

--- a/opendc-experiments/opendc-experiments-base/build.gradle.kts
+++ b/opendc-experiments/opendc-experiments-base/build.gradle.kts
@@ -105,36 +105,3 @@ val generateDocs by tasks.registering(JavaExec::class) {
         projectDir.resolve("src/main/kotlin/org/opendc/experiments/base/experiment/specs").absolutePath,
     )
 }
-
-val createScenarioApp by tasks.creating(CreateStartScripts::class) {
-    dependsOn(tasks.jar)
-
-    applicationName = "OpenDCExperimentRunner"
-    mainClass.set("org.opendc.experiments.base.runner.ExperimentCli")
-    classpath = tasks.jar.get().outputs.files + configurations["runtimeClasspath"]
-    outputDir = layout.buildDirectory.dir("scripts").get().asFile
-}
-
-// Create custom Scenario distribution
-distributions {
-    main {
-        distributionBaseName.set("OpenDCExperimentRunner")
-
-        contents {
-            from("README.md")
-            from("LICENSE.txt")
-            from("../../LICENSE.txt") {
-                rename { "LICENSE-OpenDC.txt" }
-            }
-
-            into("bin") {
-                from(createScenarioApp)
-            }
-
-            into("lib") {
-                from(tasks.jar)
-                from(configurations["runtimeClasspath"])
-            }
-        }
-    }
-}


### PR DESCRIPTION
## Summary

This PR changes the creation of the OpenDCExperimentRunner from opendc-experiment-base to opendc-cli. 
This is done because opendc-experiment-base is deprecated, and its capabilities have been moved to opendc-cli.

## Implementation Notes :hammer_and_pick:

N / A

## External Dependencies :four_leaf_clover:

N / A

## Breaking API Changes :warning:

N / A

*Simply specify none (N/A) if not applicable.*